### PR TITLE
Curry the run method

### DIFF
--- a/bin/stratis
+++ b/bin/stratis
@@ -26,7 +26,7 @@ def main():
     """
     The main method.
     """
-    return run(sys.argv[1:])
+    return run()(sys.argv[1:])
 
 if __name__ == "__main__":
     main()

--- a/src/stratis_cli/_main.py
+++ b/src/stratis_cli/_main.py
@@ -21,19 +21,26 @@ import dbus
 
 from ._parser import gen_parser
 
-def run(command_line_args):
+def run():
     """
-    Run according to the arguments passed.
+    Generate a function that parses arguments and executes.
     """
     parser = gen_parser()
-    result = parser.parse_args(command_line_args)
-    if result.subparser_name is None:
-        parser.print_help()
-    else:
-        try:
-            result.func(result)
-        except dbus.exceptions.DBusException as err:
-            if result.propagate:
-                raise
-            sys.exit(err.get_dbus_message())
-    return 0
+
+    def the_func(command_line_args):
+        """
+        Run according to the arguments passed.
+        """
+        result = parser.parse_args(command_line_args)
+        if result.subparser_name is None:
+            parser.print_help()
+        else:
+            try:
+                result.func(result)
+            except dbus.exceptions.DBusException as err:
+                if result.propagate:
+                    raise
+                sys.exit(err.get_dbus_message())
+        return 0
+
+    return the_func

--- a/tests/_misc.py
+++ b/tests/_misc.py
@@ -24,6 +24,8 @@ import sys
 
 from hypothesis import strategies
 
+from stratis_cli import run
+
 try:
     _STRATISD = os.environ['STRATISD']
 except KeyError:
@@ -79,3 +81,5 @@ class ServiceR(ServiceABC):
 
 
 Service = ServiceR
+
+RUNNER = run()

--- a/tests/integration/logical/test_create.py
+++ b/tests/integration/logical/test_create.py
@@ -21,11 +21,11 @@ import unittest
 
 from stratisd_client_dbus import StratisdErrorsGen
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliRuntimeError
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -59,7 +59,7 @@ class CreateTestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)
 
 
 @unittest.skip("Creation of a volume could fail if no room in pool.")
@@ -81,7 +81,7 @@ class Create2TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -94,7 +94,7 @@ class Create2TestCase(unittest.TestCase):
         Creation of the volume should succeed since pool is available.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        run(command_line)
+        RUNNER(command_line)
 
 
 class Create3TestCase(unittest.TestCase):
@@ -115,9 +115,9 @@ class Create3TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -132,6 +132,6 @@ class Create3TestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
         with self.assertRaises(StratisCliRuntimeError) as ctxt:
-            run(command_line)
+            RUNNER(command_line)
         expected_error = StratisdErrorsGen.get_object().ALREADY_EXISTS
         self.assertEqual(ctxt.exception.rc, expected_error)

--- a/tests/integration/logical/test_destroy.py
+++ b/tests/integration/logical/test_destroy.py
@@ -19,10 +19,10 @@ Test 'destroy'.
 import time
 import unittest
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -57,7 +57,7 @@ class DestroyTestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)
 
 
 class Destroy2TestCase(unittest.TestCase):
@@ -79,7 +79,7 @@ class Destroy2TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create', self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -93,7 +93,7 @@ class Destroy2TestCase(unittest.TestCase):
         volume is gone.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        run(command_line)
+        RUNNER(command_line)
 
 
 class Destroy3TestCase(unittest.TestCase):
@@ -116,10 +116,10 @@ class Destroy3TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create', self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
         command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLNAMES
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -133,4 +133,4 @@ class Destroy3TestCase(unittest.TestCase):
         volume is gone.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        run(command_line)
+        RUNNER(command_line)

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -19,10 +19,10 @@ Test 'create'.
 import time
 import unittest
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -55,7 +55,7 @@ class ListTestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME]
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)
 
 
 class List2TestCase(unittest.TestCase):
@@ -75,7 +75,7 @@ class List2TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -88,7 +88,7 @@ class List2TestCase(unittest.TestCase):
         Listing the volumes in an empty pool should succeed.
         """
         command_line = self._MENU + [self._POOLNAME]
-        run(command_line)
+        RUNNER(command_line)
 
 
 class List3TestCase(unittest.TestCase):
@@ -109,10 +109,10 @@ class List3TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create', self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
         command_line = \
            ['filesystem', 'create', self._POOLNAME] + self._VOLUMES
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -125,4 +125,4 @@ class List3TestCase(unittest.TestCase):
         Listing the volumes in a non-empty pool should succeed.
         """
         command_line = self._MENU + [self._POOLNAME]
-        run(command_line)
+        RUNNER(command_line)

--- a/tests/integration/logical/test_snapshot.py
+++ b/tests/integration/logical/test_snapshot.py
@@ -21,10 +21,10 @@ import unittest
 
 from stratisd_client_dbus import StratisdErrorsGen
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliRuntimeError
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -61,7 +61,7 @@ class SnapshotTestCase(unittest.TestCase):
         command_line = \
            self._MENU + [self._POOLNAME] + [self._ORIGIN] + [self._SNAP]
         with self.assertRaises(StratisCliRuntimeError) as ctxt:
-            run(command_line)
+            RUNNER(command_line)
         expected_error = StratisdErrorsGen.get_object().POOL_NOTFOUND
         self.assertEqual(ctxt.exception.rc, expected_error)
 
@@ -86,7 +86,7 @@ class Snapshot1TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -101,7 +101,7 @@ class Snapshot1TestCase(unittest.TestCase):
         command_line = \
            self._MENU + [self._POOLNAME] + [self._ORIGIN] + [self._SNAP]
         with self.assertRaises(StratisCliRuntimeError) as ctxt:
-            run(command_line)
+            RUNNER(command_line)
         expected_error = StratisdErrorsGen.get_object().VOLUME_NOTFOUND
         self.assertEqual(ctxt.exception.rc, expected_error)
 
@@ -126,10 +126,10 @@ class Snapshot2TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
         command_line = ['filesystem', 'create'] + [self._POOLNAME] + [self._ORIGIN]
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -144,4 +144,4 @@ class Snapshot2TestCase(unittest.TestCase):
         """
         command_line = \
            self._MENU + [self._POOLNAME] + [self._ORIGIN] + [self._SNAP]
-        run(command_line)
+        RUNNER(command_line)

--- a/tests/integration/physical/test_add.py
+++ b/tests/integration/physical/test_add.py
@@ -19,10 +19,10 @@ Test 'create'.
 import time
 import unittest
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -57,7 +57,7 @@ class AddTestCase(unittest.TestCase):
         command_line = self._MENU + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)
 
 
 @unittest.skip("Can't test this because not modeling ownership of devs.")
@@ -80,7 +80,7 @@ class Add2TestCase(unittest.TestCase):
         time.sleep(1)
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + self._DEVICES
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -94,7 +94,7 @@ class Add2TestCase(unittest.TestCase):
         unused by pool, but should fail otherwise.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        run(command_line)
+        RUNNER(command_line)
 
 @unittest.skip('Not able to track if devices are in use.')
 class Add3TestCase(unittest.TestCase):
@@ -115,7 +115,7 @@ class Add3TestCase(unittest.TestCase):
         time.sleep(1)
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + self._DEVICES[:1]
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -129,4 +129,4 @@ class Add3TestCase(unittest.TestCase):
         unused by others, but should fail otherwise.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES[1:]
-        run(command_line)
+        RUNNER(command_line)

--- a/tests/integration/physical/test_list.py
+++ b/tests/integration/physical/test_list.py
@@ -19,10 +19,10 @@ Test 'create'.
 import time
 import unittest
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -56,7 +56,7 @@ class ListTestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME]
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)
 
 
 @unittest.skip("Not currently listing devices in DBus API.")
@@ -77,7 +77,7 @@ class List2TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -90,4 +90,4 @@ class List2TestCase(unittest.TestCase):
         Listing the devices should succeed.
         """
         command_line = self._MENU + [self._POOLNAME]
-        run(command_line)
+        RUNNER(command_line)

--- a/tests/integration/pool/test_create.py
+++ b/tests/integration/pool/test_create.py
@@ -19,10 +19,10 @@ Test 'create'.
 import time
 import unittest
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliRuntimeError
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -59,7 +59,7 @@ class CreateTestCase(unittest.TestCase):
            [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
         with self.assertRaises(SystemExit):
-            run(command_line)
+            RUNNER(command_line)
 
 
 class Create2TestCase(unittest.TestCase):
@@ -92,7 +92,7 @@ class Create2TestCase(unittest.TestCase):
            self._MENU + \
            [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
 
 class Create3TestCase(unittest.TestCase):
@@ -112,7 +112,7 @@ class Create3TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create', self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -129,4 +129,4 @@ class Create3TestCase(unittest.TestCase):
            [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
         with self.assertRaises(StratisCliRuntimeError):
-            run(command_line)
+            RUNNER(command_line)

--- a/tests/integration/pool/test_destroy.py
+++ b/tests/integration/pool/test_destroy.py
@@ -21,11 +21,11 @@ import unittest
 
 from stratisd_client_dbus import StratisdErrorsGen
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliRuntimeError
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -60,7 +60,7 @@ class Destroy1TestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME]
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)
 
 
 class Destroy2TestCase(unittest.TestCase):
@@ -81,7 +81,7 @@ class Destroy2TestCase(unittest.TestCase):
            ['pool', 'create'] + \
            [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -94,7 +94,7 @@ class Destroy2TestCase(unittest.TestCase):
         The pool was just created, so must be destroyable.
         """
         command_line = self._MENU + [self._POOLNAME]
-        run(command_line)
+        RUNNER(command_line)
 
 
 class Destroy3TestCase(unittest.TestCase):
@@ -117,13 +117,13 @@ class Destroy3TestCase(unittest.TestCase):
            ['pool', 'create'] + \
            [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
         command_line = \
            ['filesystem', 'create'] + \
            [self._POOLNAME] + \
            [self._VOLNAME]
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -137,7 +137,7 @@ class Destroy3TestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME]
         with self.assertRaises(StratisCliRuntimeError) as ctxt:
-            run(command_line)
+            RUNNER(command_line)
         expected_error = StratisdErrorsGen.get_object().BUSY
         self.assertEqual(ctxt.exception.rc, expected_error)
 
@@ -146,6 +146,6 @@ class Destroy3TestCase(unittest.TestCase):
         This should succeed since the filesystem is removed first.
         """
         command_line = ['filesystem', 'destroy', self._POOLNAME, self._VOLNAME]
-        run(command_line)
+        RUNNER(command_line)
         command_line = self._MENU + [self._POOLNAME]
-        run(command_line)
+        RUNNER(command_line)

--- a/tests/integration/pool/test_list.py
+++ b/tests/integration/pool/test_list.py
@@ -19,9 +19,9 @@ Test 'list'.
 import time
 import unittest
 
-from stratis_cli._main import run
 
 from .._misc import _device_list
+from .._misc import RUNNER
 from .._misc import Service
 
 _DEVICE_STRATEGY = _device_list(1)
@@ -52,7 +52,7 @@ class ListTestCase(unittest.TestCase):
         List should just succeed, even though there is nothing to list.
         """
         command_line = self._MENU
-        run(command_line)
+        RUNNER(command_line)
 
 
 class List2TestCase(unittest.TestCase):
@@ -72,7 +72,7 @@ class List2TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -85,4 +85,4 @@ class List2TestCase(unittest.TestCase):
         List should just succeed.
         """
         command_line = self._MENU
-        run(command_line)
+        RUNNER(command_line)

--- a/tests/integration/pool/test_rename.py
+++ b/tests/integration/pool/test_rename.py
@@ -19,9 +19,9 @@ Test 'rename'.
 import time
 import unittest
 
-from stratis_cli._main import run
 from stratis_cli._errors import StratisCliDbusLookupError
 
+from .._misc import RUNNER
 from .._misc import Service
 from .._misc import _device_list
 
@@ -56,7 +56,7 @@ class Rename1TestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME, self._NEW_POOLNAME]
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)
 
     def testSameName(self):
         """
@@ -64,7 +64,7 @@ class Rename1TestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME, self._POOLNAME]
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)
 
 
 class Rename2TestCase(unittest.TestCase):
@@ -85,7 +85,7 @@ class Rename2TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create'] + [self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -98,14 +98,14 @@ class Rename2TestCase(unittest.TestCase):
         This should succeed because pool exists.
         """
         command_line = self._MENU + [self._POOLNAME, self._NEW_POOLNAME]
-        run(command_line)
+        RUNNER(command_line)
 
     def testSameName(self):
         """
         This should succeed, because renaming to self makes sense.
         """
         command_line = self._MENU + [self._POOLNAME, self._POOLNAME]
-        run(command_line)
+        RUNNER(command_line)
 
     def testNonExistentPool(self):
         """
@@ -113,4 +113,4 @@ class Rename2TestCase(unittest.TestCase):
         """
         command_line = self._MENU + ["nopool", self._POOLNAME]
         with self.assertRaises(StratisCliDbusLookupError):
-            run(command_line)
+            RUNNER(command_line)

--- a/tests/integration/test_misc.py
+++ b/tests/integration/test_misc.py
@@ -20,14 +20,13 @@ import unittest
 
 from stratisd_client_dbus import get_object
 
-from stratis_cli import run
-
 from stratis_cli._actions._misc import GetObjectPath
 
 from stratis_cli._constants import TOP_OBJECT
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from ._misc import _device_list
+from ._misc import RUNNER
 from ._misc import Service
 
 
@@ -78,7 +77,7 @@ class GetPool1TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create', self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -121,7 +120,7 @@ class GetVolume1TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create', self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """
@@ -161,10 +160,10 @@ class GetVolume2TestCase(unittest.TestCase):
         command_line = \
            ['pool', 'create', self._POOLNAME] + \
            _DEVICE_STRATEGY.example()
-        run(command_line)
+        RUNNER(command_line)
         command_line = \
            ['filesystem', 'create', self._POOLNAME, self._VOLNAME]
-        run(command_line)
+        RUNNER(command_line)
 
     def tearDown(self):
         """

--- a/tests/integration/test_stratis.py
+++ b/tests/integration/test_stratis.py
@@ -19,8 +19,7 @@ Test 'stratisd'.
 import time
 import unittest
 
-from stratis_cli._main import run
-
+from ._misc import RUNNER
 from ._misc import Service
 
 
@@ -49,21 +48,21 @@ class StratisTestCase(unittest.TestCase):
         Getting version should just succeed.
         """
         command_line = self._MENU + ['version']
-        run(command_line)
+        RUNNER(command_line)
 
     def testStratisRedundancy(self):
         """
         Getting redundancy should just succeed.
         """
         command_line = self._MENU + ['redundancy']
-        run(command_line)
+        RUNNER(command_line)
 
     def testStratisNoOptions(self):
         """
         Exactly one option should be set, this should succeed, but print help.
         """
         command_line = self._MENU
-        run(command_line)
+        RUNNER(command_line)
 
     def testStratisTwoOptions(self):
         """
@@ -72,4 +71,4 @@ class StratisTestCase(unittest.TestCase):
         """
         command_line = self._MENU + ['redundancy', 'version']
         with self.assertRaises(SystemExit):
-            run(command_line)
+            RUNNER(command_line)


### PR DESCRIPTION
Make generating the parser and parsing the command-line separate stages.

Signed-off-by: mulhern <amulhern@redhat.com>