### PR TITLE
Change stratis to explicitly use Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,13 +44,10 @@ directory and set the ``PYTHONPATH`` environment variable to include
 library dependencies. For example (if using bash shell)::
 
    > export PYTHONPATH="src:../stratisd-client-dbus/src:../into-dbus-python/src:../dbus-signature-pyparsing/src"
-   > python3 bin/stratis --help
+   > ./bin/stratis --help
 
 Since ``stratis`` uses stratisd's API, most operations will fail
 unless you are also running the `Stratis daemon <https://github.com/stratis-storage/stratisd>`_.
-
-You may have to explicitly invoke the Python 3 interpreter if Python 3 is
-not your default Python implementation, as shown above.
 
 Testing
 -------

--- a/bin/stratis
+++ b/bin/stratis
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2016 Red Hat, Inc.
 #


### PR DESCRIPTION
Since we are Py3 only, we don't want to inadvertently fall back to it if
that's the default python on the system. This can result in errors that
are not obviously due to using the wrong Python version. It's better to
just insist on the interpreter we need.

Alter README based on this.

resolves #55

Signed-off-by: Andy Grover <agrover@redhat.com>