### PR TITLE
List pool and filesystem names instead of object paths

### DIFF
--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -23,6 +23,7 @@ from stratisd_client_dbus import Pool
 from stratisd_client_dbus import StratisdErrorsGen
 from stratisd_client_dbus import get_managed_objects
 from stratisd_client_dbus import get_object
+from stratisd_client_dbus import GMOFilesystem
 
 from .._errors import StratisCliRuntimeError
 
@@ -66,10 +67,10 @@ class LogicalActions(object):
         pool_object_path = \
            GetObjectPath.get_pool(proxy, spec={'Name': namespace.pool_name})
 
-        for object_path, _ in get_managed_objects(proxy).filesystems(
+        for _, info in get_managed_objects(proxy).filesystems(
                    props={'Pool': pool_object_path}
            ):
-            print(object_path)
+            print(GMOFilesystem(info).Name())
 
         return
 

--- a/src/stratis_cli/_actions/_top.py
+++ b/src/stratis_cli/_actions/_top.py
@@ -23,6 +23,7 @@ from stratisd_client_dbus import Pool
 from stratisd_client_dbus import StratisdErrorsGen
 from stratisd_client_dbus import get_managed_objects
 from stratisd_client_dbus import get_object
+from stratisd_client_dbus import GMOPool
 
 from .._constants import TOP_OBJECT
 
@@ -70,8 +71,8 @@ class TopActions(object):
         # pylint: disable=unused-argument
         proxy = get_object(TOP_OBJECT)
 
-        for object_path, _ in get_managed_objects(proxy).pools():
-            print(object_path)
+        for _, info in get_managed_objects(proxy).pools():
+            print(GMOPool(info).Name())
 
         return
 


### PR DESCRIPTION
The given name is more useful to users than arbitrary object path.

Signed-off-by: Andy Grover <agrover@redhat.com>