### PR TITLE
Allow stratis-cli to have a three part version number

### DIFF
--- a/src/stratis_cli/_version.py
+++ b/src/stratis_cli/_version.py
@@ -18,5 +18,5 @@
     .. moduleauthor::  mulhern  <amulhern@redhat.com>
 """
 
-__version__ = '0.01'
-__version_info__ = tuple(int(x) for x in __version__.split('.'))
+__version_info__ = (0, 0, 1)
+__version__ = '.'.join(str(x) for x in __version_info__)


### PR DESCRIPTION
More flexibility to put out patch releases if necessary.
Build the version string from the digits, instead of splitting up the
version string to get digits.

Set initial version to 0.1.0.

Signed-off-by: mulhern <amulhern@redhat.com>