### PR TITLE
Print subcommand-level help if no subsubcommand given

### DIFF
--- a/src/stratis_cli/_main.py
+++ b/src/stratis_cli/_main.py
@@ -32,15 +32,12 @@ def run():
         Run according to the arguments passed.
         """
         result = parser.parse_args(command_line_args)
-        if result.subparser_name is None:
-            parser.print_help()
-        else:
-            try:
-                result.func(result)
-            except dbus.exceptions.DBusException as err:
-                if result.propagate:
-                    raise
-                sys.exit(err.get_dbus_message())
+        try:
+            result.func(result)
+        except dbus.exceptions.DBusException as err:
+            if result.propagate:
+                raise
+            sys.exit(err.get_dbus_message())
         return 0
 
     return the_func

--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -27,6 +27,9 @@ from ._logical import LOGICAL_SUBCMDS
 from ._physical import PHYSICAL_SUBCMDS
 from ._pool import POOL_SUBCMDS
 
+# pylint: disable=undefined-variable
+PRINT_HELP = lambda parser: lambda _: parser.print_help()
+
 def add_args(parser, args=None):
     """
     Call subcommand.add_argument() based on args list.
@@ -34,7 +37,6 @@ def add_args(parser, args=None):
     if args is not None:
         for name, arg in args:
             parser.add_argument(name, **arg)
-
 
 def add_subcommand(subparser, cmd):
     """
@@ -45,15 +47,13 @@ def add_subcommand(subparser, cmd):
 
     subcmds = info.get('subcmds')
     if subcmds is not None:
-        subparsers = parser.add_subparsers(dest='subparser_name')
+        subparsers = parser.add_subparsers(title='subcommands')
         for subcmd in subcmds:
             add_subcommand(subparsers, subcmd)
 
     add_args(parser, info.get('args', []))
 
-    f = info.get('func')
-    if f is not None:
-        parser.set_defaults(func=f)
+    parser.set_defaults(func=info.get('func', PRINT_HELP(parser)))
 
 DAEMON_SUBCMDS = [
     ('redundancy',
@@ -120,9 +120,11 @@ def gen_parser():
 
     add_args(parser, GEN_ARGS)
 
-    subparsers = parser.add_subparsers(dest='subparser_name')
+    subparsers = parser.add_subparsers(title='subcommands')
 
     for subcmd in ROOT_SUBCOMMANDS:
         add_subcommand(subparsers, subcmd)
+
+    parser.set_defaults(func=PRINT_HELP(parser))
 
     return parser


### PR DESCRIPTION
If a subcommand is given but no sub-subcommand, print the help for the
subcommand, not the top-level help. e.g. 'stratis pool' w/o giving a
pool subcommand prints the pool help.

The change is: we always set 'func'. If it's not given, we set it to print
help. (A lambda is used because we call func with the Namespace
as argument, whereas parser.print_help() doesn't want/need this.)

Also, we no longer need to set 'dest' for subparsers since it's no longer
checked.

However, we do want to pass a title parameter to add_subparsers. This is
necessary to have 'subcommands' heading in help, rather than 'positional
parameters'. (This seems a little weird, but whatever.)

Signed-off-by: Andy Grover <agrover@redhat.com>