### PR TITLE
Fix pool destroy and rename

### DIFF
--- a/src/stratis_cli/_actions/_top.py
+++ b/src/stratis_cli/_actions/_top.py
@@ -90,7 +90,7 @@ class TopActions(object):
            GetObjectPath.get_pool(proxy, spec={'Name': namespace.pool_name})
 
         (_, rc, message) = \
-           Manager.DestroyPool(proxy, pool_object_path=pool_object_path)
+           Manager.DestroyPool(proxy, pool=pool_object_path)
 
         if rc != StratisdErrorsGen.get_object().OK:
             raise StratisCliRuntimeError(rc, message)
@@ -108,7 +108,7 @@ class TopActions(object):
            GetObjectPath.get_pool(proxy, spec={'Name': namespace.current})
         )
 
-        (_, rc, message) = Pool.SetName(pool_object, new_name=namespace.new)
+        (_, rc, message) = Pool.SetName(pool_object, name=namespace.new)
 
         stratisd_errors = StratisdErrorsGen.get_object()
         if rc != stratisd_errors.OK:

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -68,8 +68,7 @@ class StratisCliValueError(StratisCliError):
         if self._msg:
             fmt_str = self._FMT_STR + ": %s"
             return fmt_str % (self._value, self._param, self._msg)
-        else:
-            return self._FMT_STR % (self._value, self._param)
+        return self._FMT_STR % (self._value, self._param)
 
 
 class StratisCliValueUnimplementedError(StratisCliValueError):


### PR DESCRIPTION
A couple spots were left over using old names, and this caused "Bad keys"
errors.

Signed-off-by: Andy Grover <agrover@redhat.com>