### PR TITLE
Initial Blockdev support

### DIFF
--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -76,7 +76,13 @@ GitHub for issues and development::
 'stratisd' projects, based on likelihood of issue being with the command-line
 tool or the service daemon.
 Mailing list::
-	stratis-devel@lists.fedorahosted.org for general development discussion
+	stratis-devel@lists.fedorahosted.org for general development
+	discussion
+Unknown values::
+	stratis-cli uses the Stratis API. If the API returns values that
+	stratis-cli cannot interpret, stratis-cli will substitute "???". If
+	encountered, upgrading to the latest version of stratis-cli, or filing
+	an issue, is recommended.
 
 LICENSE
 -------

--- a/src/stratis_cli/_actions/_constants.py
+++ b/src/stratis_cli/_actions/_constants.py
@@ -27,3 +27,7 @@ REDUNDANCY = {
 }
 
 SECTOR_SIZE = 512
+
+# This string is used in all instances where an uninterpretable value is
+# retrieved from the API.
+UNKNOWN_VALUE_MARKER = "???"

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -133,7 +133,42 @@ SPECS = {
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
 </property>
 </interface>
+""",
+"org.storage.stratis1.blockdev" :
 """
+<interface name="org.storage.stratis1.blockdev">
+<method name="SetUserInfo">
+<arg name="id" type="s" direction="in"/>
+<arg name="changed" type="b" direction="out"/>
+<arg name="return_code" type="q" direction="out"/>
+<arg name="return_string" type="s" direction="out"/>
+</method>
+<property name="Devnode" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="HardwareInfo" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="InitializationTime" type="t" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="Pool" type="o" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="State" type="q" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+</property>
+<property name="TotalPhysicalSize" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+</property>
+<property name="UserInfo" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+</property>
+<property name="Uuid" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+</interface>
+""",
 }
 
 Filesystem = make_class(
@@ -160,6 +195,10 @@ MOFilesystem = managed_object_class(
 MOPool = managed_object_class(
    "MOPool",
    ET.fromstring(SPECS['org.storage.stratis1.pool'])
+)
+MODev = managed_object_class(
+   "MODev",
+   ET.fromstring(SPECS['org.storage.stratis1.blockdev'])
 )
 
 def _unique_wrapper(interface, func):
@@ -196,3 +235,6 @@ filesystems = _unique_wrapper('org.storage.stratis1.filesystem', _filesystems)
 
 _pools = mo_query_builder(ET.fromstring(SPECS['org.storage.stratis1.pool']))
 pools = _unique_wrapper('org.storage.stratis1.pool', _pools)
+
+_devs = mo_query_builder(ET.fromstring(SPECS['org.storage.stratis1.blockdev']))
+devs = _unique_wrapper('org.storage.stratis1.blockdev', _devs)

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -66,4 +66,4 @@ def print_table(
                width=column_lengths[index]
             )
             print(line, end='', file=file)
-    print(file=file)
+        print(file=file)

--- a/tests/integration/physical/test_list.py
+++ b/tests/integration/physical/test_list.py
@@ -28,7 +28,6 @@ from .._misc import Service
 _DEVICE_STRATEGY = _device_list(1)
 
 
-@unittest.skip("Not currently listing devices in DBus API.")
 class ListTestCase(unittest.TestCase):
     """
     Test listing devices for a non-existant pool.
@@ -59,7 +58,6 @@ class ListTestCase(unittest.TestCase):
             RUNNER(command_line)
 
 
-@unittest.skip("Not currently listing devices in DBus API.")
 class List2TestCase(unittest.TestCase):
     """
     Test listing devices in an existing pool.


### PR DESCRIPTION
Add introspection schema, print info on a pool's blockdevs, and fix a format error.

Waiting on PR #75 to be merged before using `justbytes` here, and then we'll be updating the last commit in this PR to also use it for printing size.