### PR TITLE
Delete some obsoleted constants

### DIFF
--- a/src/stratis_cli/_actions/_constants.py
+++ b/src/stratis_cli/_actions/_constants.py
@@ -20,10 +20,4 @@ SERVICE = 'org.storage.stratis1'
 TOP_OBJECT = '/org/storage/stratis1'
 MANAGER_INTERFACE = 'org.storage.stratis1.Manager'
 
-SERVICE_UNKNOWN_ERROR = 'org.freedesktop.DBus.Error.ServiceUnknown'
-
-REDUNDANCY = {
-   'none' : 'STRATIS_RAID_TYPE_SINGLE'
-}
-
 SECTOR_SIZE = 512


### PR DESCRIPTION
SERVICE_UNKNOWN_ERROR is unused and can be redefined if necessary.
REDUNDANCY is now handled differently, in a different file.

Signed-off-by: mulhern <amulhern@redhat.com>