### PR TITLE
remove the unittest.skip tag for Create2TestCase

### DIFF
--- a/tests/integration/logical/test_create.py
+++ b/tests/integration/logical/test_create.py
@@ -65,12 +65,11 @@ class CreateTestCase(unittest.TestCase):
             RUNNER(command_line)
 
 
-@unittest.skip("Creation of a volume could fail if no room in pool.")
 class Create2TestCase(unittest.TestCase):
     """
     Test creating a volume w/ a pool.
     """
-    _MENU = ['--propagate', 'filesystem', 'pool', 'create']
+    _MENU = ['--propagate', 'filesystem', 'create']
     _POOLNAME = 'deadpool'
     _VOLNAMES = ['oubliette', 'mnemosyne']
 


### PR DESCRIPTION
Also minor fix for the _MENU parameters

Signed-off-by: Todd Gill <tgill@redhat.com>