### PR TITLE
Now catch dbus-python-client-gen runtime errors in main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
         ],
     install_requires = [
        'dbus-client-gen>=0.2',
-       'dbus-python-client-gen>=0.4',
+       'dbus-python-client-gen>=0.5',
        'justbytes>=0.10',
     ],
     package_dir={"": "src"},

--- a/src/stratis_cli/_main.py
+++ b/src/stratis_cli/_main.py
@@ -19,6 +19,8 @@ import sys
 
 import dbus
 
+from dbus_python_client_gen import DPClientRuntimeError
+
 from ._errors import StratisCliError
 from ._parser import gen_parser
 
@@ -41,7 +43,7 @@ def run():
             if result.propagate:
                 raise
             sys.exit("Execution failed: %s" % err.get_dbus_message())
-        except StratisCliError as err:
+        except (DPClientRuntimeError, StratisCliError) as err:
             if result.propagate:
                 raise
             sys.exit("Execution failed: %s" % str(err))


### PR DESCRIPTION
Previously the name was not exported, so they could not be caught
explicitly.

Signed-off-by: mulhern <amulhern@redhat.com>