### PR TITLE
Update command_line construction to be consistent

### DIFF
--- a/tests/integration/logical/test_create.py
+++ b/tests/integration/logical/test_create.py
@@ -80,9 +80,8 @@ class Create2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):
@@ -114,9 +113,8 @@ class Create3TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            +  _DEVICE_STRATEGY.example()
         RUNNER(command_line)
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
         RUNNER(command_line)

--- a/tests/integration/logical/test_destroy.py
+++ b/tests/integration/logical/test_destroy.py
@@ -76,9 +76,8 @@ class Destroy2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create', self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):
@@ -113,9 +112,8 @@ class Destroy3TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create', self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
         command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLNAMES

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -72,9 +72,8 @@ class List2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create'] + [self._POOLNAME] \
+            +  _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):
@@ -106,12 +105,10 @@ class List3TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create', self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
-        command_line = \
-           ['filesystem', 'create', self._POOLNAME] + self._VOLUMES
+        command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLUMES
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/physical/test_add.py
+++ b/tests/integration/physical/test_add.py
@@ -54,8 +54,8 @@ class AddTestCase(unittest.TestCase):
         """
         Adding the devices must fail since the pool does not exist.
         """
-        command_line = self._MENU + [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = self._MENU + [self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         with self.assertRaises(StratisCliDbusLookupError):
             RUNNER(command_line)
 
@@ -78,8 +78,7 @@ class Add2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + [self._POOLNAME] + self._DEVICES
+        command_line = ['pool', 'create', self._POOLNAME] + self._DEVICES
         RUNNER(command_line)
 
     def tearDown(self):
@@ -113,8 +112,7 @@ class Add3TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + [self._POOLNAME] + self._DEVICES[:1]
+        command_line = ['pool', 'create'] + [self._POOLNAME] + self._DEVICES[:1]
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/physical/test_list.py
+++ b/tests/integration/physical/test_list.py
@@ -72,9 +72,8 @@ class List2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create'] + [self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/pool/test_create.py
+++ b/tests/integration/pool/test_create.py
@@ -53,11 +53,8 @@ class CreateTestCase(unittest.TestCase):
         """
         Parser error on all redundancy that is not 'none'.
         """
-        command_line = \
-           self._MENU + \
-           ['--redundancy', 'raid6'] + \
-           [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = self._MENU + ['--redundancy', 'raid6', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         with self.assertRaises(SystemExit):
             RUNNER(command_line)
 
@@ -88,10 +85,8 @@ class Create2TestCase(unittest.TestCase):
         """
         Create expects success unless devices are already occupied.
         """
-        command_line = \
-           self._MENU + \
-           [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = self._MENU + [self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
 
@@ -109,9 +104,8 @@ class Create3TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create', self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):
@@ -124,9 +118,7 @@ class Create3TestCase(unittest.TestCase):
         """
         Create should fail trying to create new pool with same name as previous.
         """
-        command_line = \
-           self._MENU + \
-           [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = self._MENU + [self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         with self.assertRaises(StratisCliRuntimeError):
             RUNNER(command_line)

--- a/tests/integration/pool/test_destroy.py
+++ b/tests/integration/pool/test_destroy.py
@@ -80,10 +80,8 @@ class Destroy2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + \
-           [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):
@@ -116,16 +114,11 @@ class Destroy3TestCase(unittest.TestCase):
         self._service.setUp()
         time.sleep(1)
 
-        command_line = \
-           ['pool', 'create'] + \
-           [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
-        command_line = \
-           ['filesystem', 'create'] + \
-           [self._POOLNAME] + \
-           [self._VOLNAME]
+        command_line = ['filesystem', 'create', self._POOLNAME, self._VOLNAME]
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/pool/test_list.py
+++ b/tests/integration/pool/test_list.py
@@ -69,9 +69,8 @@ class List2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/pool/test_rename.py
+++ b/tests/integration/pool/test_rename.py
@@ -82,9 +82,8 @@ class Rename2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = \
-           ['pool', 'create'] + [self._POOLNAME] + \
-           _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):


### PR DESCRIPTION
Use 80 chars where possible
Combine strings into the same array if possible

Signed-off-by: Todd Gill <tgill@redhat.com>