### PR TITLE
Basic command completion

### DIFF
--- a/etc/bash_completion.d/stratis
+++ b/etc/bash_completion.d/stratis
@@ -1,0 +1,108 @@
+_stratis()
+{
+	local cur prev x2prev x3prev opts root_subcommands pool_subcommands fs_subcommands blockdev_subcommands daemon_subcommands complete_pools
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	x2prev="${COMP_WORDS[COMP_CWORD-2]}"
+	x3prev="${COMP_WORDS[COMP_CWORD-3]}"
+	opts="-h --help --version"
+	root_subcommands="--help --version daemon pool blockdev filesystem"
+	pool_subcommands="create list rename destroy"
+	fs_subcommands="create snapshot list rename destroy"
+	blockdev_subcommands="add list"
+	daemon_subcommands="redundancy version"
+
+	if [[ ${cur} == -* ]] ; then
+		COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+		return 0
+	else
+		case $prev in
+			-h|--help|--version)
+				return 0
+				;;
+			filesystem|fs)
+				COMPREPLY=( $(compgen -W "${fs_subcommands}" -- ${cur}) )
+				return 0
+				;;
+			blockdev)
+				COMPREPLY=( $(compgen -W "${blockdev_subcommands}" -- ${cur}) )
+				return 0
+				;;
+			daemon)
+				COMPREPLY=( $(compgen -W "${daemon_subcommands}" -- ${cur}) )
+				return 0
+				;;
+			pool)
+				COMPREPLY=( $(compgen -W "${pool_subcommands}" -- ${cur}) )
+				return 0
+				;;
+		esac
+		case $x2prev in
+			filesystem|fs)
+				case $prev in
+					create|snapshot|list|destroy|rename)
+						COMPREPLY=( $(compgen -W  $(stratis pool list | awk '{if (NR!=1) {print $1}}' | tr '\n' ' ') -- ${cur}) )
+						return 0
+						;;
+					-h|--help)
+						return 0;
+				esac
+				;;
+			blockdev)
+				case $prev in
+					-h|--help)
+						return 0
+						;;
+					add|list)
+						COMPREPLY=( $(compgen -W  $(stratis pool list | awk '{if (NR!=1) {print $1}}' | tr '\n' ' ') -- ${cur}) )
+						return 0
+						;;
+				esac
+				;;
+			daemon)
+				return 0
+				;;
+			pool)
+				case $prev in
+					-h|--help)
+						return 0
+						;;
+					create|list)
+						return 0
+						;;
+					rename|destroy)
+						COMPREPLY=( $(compgen -W  $(stratis pool list | awk '{if (NR!=1) {print $1}}' | tr '\n' ' ') -- ${cur}) )
+						return 0
+						;;
+				esac
+				;;
+		esac
+		case $x3prev in
+			filesystem|fs)
+				case $x2prev in
+					snapshot|destroy|rename)
+						COMPREPLY=( $(compgen -W  $(stratis filesystem list ${prev}) -- ${cur}) )
+						return 0
+						;;
+					list|create|-h|--help)
+						return 0;
+				esac
+				;;
+			blockdev)
+				return 0
+				;;
+			daemon)
+				return 0
+				;;
+			pool)
+				return 0
+				;;
+		esac
+#	If we haven't sent a reply yet...
+		COMPREPLY=( $(compgen -W "${root_subcommands}" -- ${cur}) )
+		return 0
+	fi
+	return 0
+}
+complete -F _stratis stratis


### PR DESCRIPTION
It completes the subcommands up to the pool name for all the commands that require it and the first fs name for filesystem snapshot/destroy/rename, it doesn't autocomplete fs names after the first for filesystem destroy.
It doesn't autocomplete stuff it shouldn't know how to autocomplete (like new names and snapshot names) and it doesn't autcomplete blockdev names.
Closes #1