### PR TITLE
Add a space to separate the last entry from /dev/disk/by-*/ and the first from lsblk

### DIFF
--- a/etc/bash_completion.d/stratis
+++ b/etc/bash_completion.d/stratis
@@ -15,7 +15,7 @@ _stratis()
 	fs_subcommands="create snapshot list rename destroy"
 	blockdev_subcommands="add list"
 	daemon_subcommands="redundancy version"
-	blockdevs=$(echo /dev/disk/*/*)$(lsblk -n -o name -p -l)
+	blockdevs="$(echo /dev/disk/*/*) $(lsblk -n -o name -p -l)"
 
 	if [[ ${cur} == -* ]] ; then
 		COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )


### PR DESCRIPTION
Without this change there is nothing separating the last /dev/disk/by-uuid/ entry and the first blockdev name given by lsblk so the script treats these two entries as one