### PR TITLE
Clarify some help text

### DIFF
--- a/src/stratis_cli/_parser/_physical.py
+++ b/src/stratis_cli/_parser/_physical.py
@@ -45,7 +45,7 @@ PHYSICAL_SUBCMDS = [
      )),
     ('list',
      dict(
-         help="List Pool Information",
+         help="List information about blockdevs in the pool",
          args=[
              ('pool_name',
               dict(


### PR DESCRIPTION
"blockdev list" only lists information about the blockdevs in the pool.

Signed-off-by: mulhern <amulhern@redhat.com>