### PR TITLE
Rename blockdev specific code parts from physical

### DIFF
--- a/src/stratis_cli/_actions/__init__.py
+++ b/src/stratis_cli/_actions/__init__.py
@@ -17,6 +17,6 @@ Package mediating dbus actions.
 """
 
 from ._logical import LogicalActions
-from ._physical import PhysicalActions
+from ._blockdev import BlockdevActions
 from ._stratis import StratisActions
 from ._top import TopActions

--- a/src/stratis_cli/_actions/_blockdev.py
+++ b/src/stratis_cli/_actions/_blockdev.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Miscellaneous physical actions.
+Miscellaneous actions wrt. blockdevs.
 """
 
 from __future__ import print_function
@@ -45,7 +45,7 @@ def state_val_to_string(val):
     except IndexError:
         return UNKNOWN_VALUE_MARKER
 
-class PhysicalActions(object):
+class BlockdevActions(object):
     """
     Actions on the physical aspects of a pool.
     """

--- a/src/stratis_cli/_parser/_physical.py
+++ b/src/stratis_cli/_parser/_physical.py
@@ -16,7 +16,7 @@
 Definition of block device actions to display in the CLI.
 """
 
-from .._actions import PhysicalActions
+from .._actions import BlockdevActions
 
 PHYSICAL_SUBCMDS = [
     ('add',
@@ -41,7 +41,7 @@ PHYSICAL_SUBCMDS = [
                   help="Use devices even if they appear to contain existing data"
               )),
          ],
-         func=PhysicalActions.add_device
+         func=BlockdevActions.add_device
      )),
     ('list',
      dict(
@@ -53,6 +53,6 @@ PHYSICAL_SUBCMDS = [
                   help='Pool name'
               )),
          ],
-         func=PhysicalActions.list_pool
+         func=BlockdevActions.list_pool
      )),
 ]


### PR DESCRIPTION
Cachedev will be kind of the same, and it's better to avoid confusing
name conflicts.

Signed-off-by: mulhern <amulhern@redhat.com>