### PR TITLE
PEP8 formatting for python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ branches:
 env:
     matrix:
         - TASK=lint
+        - TASK=fmt-travis
 
 script: make -f Makefile $TASK

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ coverage:
 test:
 	$(TOX) -c tox.ini -e test
 
+.PHONY: fmt
+fmt:
+	yapf --style pep8 --recursive --in-place check.py setup.py src tests
+
+.PHONY: fmt-travis
+fmt-travis:
+	yapf --style pep8 --recursive --diff check.py setup.py src tests
+
 PYREVERSE_OPTS = --output=pdf
 .PHONY: view
 view:

--- a/bin/stratis
+++ b/bin/stratis
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Entry script for stratis CLI.
 """
@@ -22,11 +21,13 @@ import sys
 
 from stratis_cli import run
 
+
 def main():
     """
     The main method.
     """
     return run()(sys.argv[1:])
+
 
 if __name__ == "__main__":
     main()

--- a/check.py
+++ b/check.py
@@ -5,28 +5,22 @@ import subprocess
 import sys
 
 arg_map = {
-   "src/stratis_cli" : [
-      "--reports=no",
-      "--disable=I",
-      "--disable=bad-continuation",
-      "--disable=duplicate-code",
-      "--disable=invalid-name",
-      "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
-   ],
-   "tests" : [
-      "--reports=no",
-      "--disable=I",
-      "--disable=bad-continuation",
-      "--disable=duplicate-code",
-      "--disable=invalid-name",
-      "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
-   ],
-   "bin/stratis" : [
-      "--reports=no",
-      "--disable=bad-continuation",
-      "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
-   ],
+    "src/stratis_cli": [
+        "--reports=no", "--disable=I", "--disable=bad-continuation",
+        "--disable=duplicate-code", "--disable=invalid-name",
+        "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
+    ],
+    "tests": [
+        "--reports=no", "--disable=I", "--disable=bad-continuation",
+        "--disable=duplicate-code", "--disable=invalid-name",
+        "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
+    ],
+    "bin/stratis": [
+        "--reports=no", "--disable=bad-continuation",
+        "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
+    ],
 }
+
 
 def get_parser():
     """
@@ -37,12 +31,12 @@ def get_parser():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-       "package",
-       choices=arg_map.keys(),
-       help="designates the package to test"
-    )
+        "package",
+        choices=arg_map.keys(),
+        help="designates the package to test")
     parser.add_argument("--ignore", help="ignore these files")
     return parser
+
 
 def get_command(namespace):
     """
@@ -54,6 +48,7 @@ def get_command(namespace):
     if namespace.ignore:
         cmd.append("--ignore=%s" % namespace.ignore)
     return cmd
+
 
 def main():
     args = get_parser().parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tox
+yapf

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,15 @@ import setuptools
 if sys.version_info[0] < 3:
     from codecs import open
 
+
 def local_file(name):
     return os.path.relpath(os.path.join(os.path.dirname(__file__), name))
+
 
 README = local_file("README.rst")
 
 with open(local_file("src/stratis_cli/_version.py")) as o:
-        exec(o.read())
+    exec(o.read())
 
 setuptools.setup(
     name='stratis-cli',
@@ -22,26 +24,22 @@ setuptools.setup(
     platforms=['Linux'],
     license='Apache 2.0',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Environment :: Console',
+        'Development Status :: 2 - Pre-Alpha', 'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: Apache Software License',
-        'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python',
+        'Operating System :: POSIX :: Linux', 'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries',
-        'Topic :: System :: Filesystems',
-        'Topic :: Systems Administration'
-        ],
-    install_requires = [
-       'dbus-client-gen>=0.2',
-       'dbus-python-client-gen>=0.5',
-       'justbytes==0.11',
+        'Topic :: System :: Filesystems', 'Topic :: Systems Administration'
+    ],
+    install_requires=[
+        'dbus-client-gen>=0.2',
+        'dbus-python-client-gen>=0.5',
+        'justbytes==0.11',
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),
-    scripts=['bin/stratis']
-    )
+    scripts=['bin/stratis'])

--- a/src/stratis_cli/__init__.py
+++ b/src/stratis_cli/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Top level of CLI.
 """

--- a/src/stratis_cli/_actions/__init__.py
+++ b/src/stratis_cli/_actions/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Package mediating dbus actions.
 """

--- a/src/stratis_cli/_actions/_connection.py
+++ b/src/stratis_cli/_actions/_connection.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Low-level interactions with the D-Bus.
 """
@@ -30,7 +29,7 @@ class Bus(object):
     _BUS = None
 
     @staticmethod
-    def get_bus(): # pragma: no cover
+    def get_bus():  # pragma: no cover
         """
         Get our bus.
         """
@@ -39,7 +38,8 @@ class Bus(object):
 
         return Bus._BUS
 
-def get_object(object_path): # pragma: no cover
+
+def get_object(object_path):  # pragma: no cover
     """
     Get an object from an object path.
 

--- a/src/stratis_cli/_actions/_constants.py
+++ b/src/stratis_cli/_actions/_constants.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 General constants.
 """

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 XML interface specifications.
 """
@@ -25,18 +24,17 @@ from dbus_python_client_gen import make_class
 
 from .._errors import StratisCliDbusLookupError
 
-
 SPECS = {
-"org.freedesktop.DBus.ObjectManager" :
-"""
+    "org.freedesktop.DBus.ObjectManager":
+    """
 <interface name="org.freedesktop.DBus.ObjectManager">
 <method name="GetManagedObjects">
 <arg name="objpath_interfaces_and_properties" type="a{oa{sa{sv}}}" direction="out"/>
 </method>
 </interface>
 """,
-"org.storage.stratis1.Manager" :
-"""
+    "org.storage.stratis1.Manager":
+    """
 <interface name="org.storage.stratis1.Manager">
 <method name="ConfigureSimulator">
 <arg name="denominator" type="u" direction="in"/>
@@ -63,8 +61,8 @@ SPECS = {
 </property>
 </interface>
 """,
-"org.storage.stratis1.pool" :
-"""
+    "org.storage.stratis1.pool":
+    """
 <interface name="org.storage.stratis1.pool">
 <method name="AddCacheDevs">
 <arg name="force" type="b" direction="in"/>
@@ -119,8 +117,8 @@ SPECS = {
 </property>
 </interface>
 """,
-"org.storage.stratis1.filesystem" :
-"""
+    "org.storage.stratis1.filesystem":
+    """
 <interface name="org.storage.stratis1.filesystem">
 <method name="SetName">
 <arg name="name" type="s" direction="in"/>
@@ -142,8 +140,8 @@ SPECS = {
 </property>
 </interface>
 """,
-"org.storage.stratis1.blockdev":
-"""
+    "org.storage.stratis1.blockdev":
+    """
 <interface name="org.storage.stratis1.blockdev">
 <method name="SetUserInfo">
 <arg name="id" type="s" direction="in"/>
@@ -182,40 +180,31 @@ SPECS = {
 """,
 }
 
-Filesystem = make_class(
-   "Filesystem",
-   ET.fromstring(SPECS['org.storage.stratis1.filesystem'])
-)
-Manager = make_class(
-   "Manager",
-   ET.fromstring(SPECS['org.storage.stratis1.Manager'])
-)
-ObjectManager = make_class(
-   "ObjectManager",
-   ET.fromstring(SPECS['org.freedesktop.DBus.ObjectManager'])
-)
-Pool = make_class(
-   "Pool",
-   ET.fromstring(SPECS['org.storage.stratis1.pool'])
-)
+Filesystem = make_class("Filesystem",
+                        ET.fromstring(
+                            SPECS['org.storage.stratis1.filesystem']))
+Manager = make_class("Manager",
+                     ET.fromstring(SPECS['org.storage.stratis1.Manager']))
+ObjectManager = make_class("ObjectManager",
+                           ET.fromstring(
+                               SPECS['org.freedesktop.DBus.ObjectManager']))
+Pool = make_class("Pool", ET.fromstring(SPECS['org.storage.stratis1.pool']))
 
 MOFilesystem = managed_object_class(
-   "MOFilesystem",
-   ET.fromstring(SPECS['org.storage.stratis1.filesystem'])
-)
-MOPool = managed_object_class(
-   "MOPool",
-   ET.fromstring(SPECS['org.storage.stratis1.pool'])
-)
-MODev = managed_object_class(
-   "MODev",
-   ET.fromstring(SPECS['org.storage.stratis1.blockdev'])
-)
+    "MOFilesystem", ET.fromstring(SPECS['org.storage.stratis1.filesystem']))
+MOPool = managed_object_class("MOPool",
+                              ET.fromstring(
+                                  SPECS['org.storage.stratis1.pool']))
+MODev = managed_object_class("MODev",
+                             ET.fromstring(
+                                 SPECS['org.storage.stratis1.blockdev']))
+
 
 def _unique_wrapper(interface, func):
     """
     Wraps other methods, implementing an additional unique parameter.
     """
+
     def the_func(managed_objects, props=None, unique=False):
         """
         Call func on managed_objects and props. If unique is True, return
@@ -239,6 +228,7 @@ def _unique_wrapper(interface, func):
         return result
 
     return the_func
+
 
 _FILESYSTEM_INTERFACE = 'org.storage.stratis1.filesystem'
 _filesystems = mo_query_builder(ET.fromstring(SPECS[_FILESYSTEM_INTERFACE]))

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Formatting for tables.
 """
@@ -19,12 +18,7 @@ Formatting for tables.
 import sys
 
 
-def print_table(
-   column_headings,
-   row_entries,
-   alignment,
-   file=sys.stdout
-):
+def print_table(column_headings, row_entries, alignment, file=sys.stdout):
     """
     Given the column headings and the row_entries, print a table.
     Align according to alignment specification and always pad with 2 spaces.
@@ -43,27 +37,24 @@ def print_table(
     num_columns = len(column_headings)
 
     column_lengths = [
-       max(
-          max((len(e[index]) for e in row_entries), default=0),
-          len(column_headings[index])
-       ) + 2 for index in range(num_columns)
+        max(
+            max((len(e[index]) for e in row_entries), default=0),
+            len(column_headings[index])) + 2 for index in range(num_columns)
     ]
 
     for index in range(num_columns):
         line = '{0:{align}{width}}'.format(
-           column_headings[index],
-           align=alignment[index],
-           width=column_lengths[index]
-        )
+            column_headings[index],
+            align=alignment[index],
+            width=column_lengths[index])
         print(line, end='', file=file)
     print(file=file)
 
     for row in row_entries:
         for index in range(num_columns):
             line = '{0:{align}{width}}'.format(
-               row[index],
-               align=alignment[index],
-               width=column_lengths[index]
-            )
+                row[index],
+                align=alignment[index],
+                width=column_lengths[index])
             print(line, end='', file=file)
         print(file=file)

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Miscellaneous logical actions.
 """
@@ -48,15 +47,10 @@ class LogicalActions(object):
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.pool_name},
-           unique=True
-        )
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
 
         (_, rc, message) = Pool.Methods.CreateFilesystems(
-           get_object(pool_object_path),
-           {'specs': namespace.fs_name}
-        )
+            get_object(pool_object_path), {'specs': namespace.fs_name})
 
         if rc != StratisdErrors.OK:
             raise StratisCliRuntimeError(rc, message)
@@ -72,28 +66,16 @@ class LogicalActions(object):
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
 
         (pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.pool_name},
-           unique=True
-        )
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
         matching_filesystems = filesystems(
-           managed_objects,
-           props={'Pool': pool_object_path}
-        )
+            managed_objects, props={'Pool': pool_object_path})
 
-        tables = [
-           [
-              MOFilesystem(info).Name(),
-           ] for _, info in matching_filesystems
-        ]
+        tables = [[
+            MOFilesystem(info).Name(),
+        ] for _, info in matching_filesystems]
 
-        print_table(
-           [
-              'Name'
-           ],
-           sorted(tables, key=lambda entry: entry[0]),
-           ['<']
-        )
+        print_table(['Name'], sorted(tables, key=lambda entry: entry[0]),
+                    ['<'])
 
         return
 
@@ -108,10 +90,7 @@ class LogicalActions(object):
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
 
         (pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.pool_name},
-           unique=True
-        )
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
         fs_object_paths = [
            op for name in namespace.fs_name for (op, _) in \
            filesystems(
@@ -142,15 +121,14 @@ class LogicalActions(object):
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
 
         (pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.pool_name},
-           unique=True
-        )
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
         (origin_fs_object_path, _) = filesystems(
             managed_objects,
-            props={'Name': namespace.origin_name, 'Pool': pool_object_path},
-            unique=True
-        )
+            props={
+                'Name': namespace.origin_name,
+                'Pool': pool_object_path
+            },
+            unique=True)
 
         (_, rc, message) = \
            Pool.Methods.SnapshotFilesystem(
@@ -163,6 +141,7 @@ class LogicalActions(object):
             raise StratisCliRuntimeError(rc, message)
 
         return
+
     @staticmethod
     def rename_fs(namespace):
         """
@@ -171,20 +150,17 @@ class LogicalActions(object):
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = pools(
-            managed_objects,
-            props={'Name': namespace.pool_name},
-            unique=True
-        )
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
         (fs_object_path, _) = filesystems(
             managed_objects,
-            props={'Name': namespace.fs_name, 'Pool': pool_object_path},
-            unique=True
-        )
+            props={
+                'Name': namespace.fs_name,
+                'Pool': pool_object_path
+            },
+            unique=True)
 
         (_, rc, message) = Filesystem.Methods.SetName(
-            get_object(fs_object_path),
-            {'name': namespace.new_name}
-        )
+            get_object(fs_object_path), {'name': namespace.new_name})
 
         if rc != StratisdErrors.OK:
             raise StratisCliRuntimeError(rc, message)

--- a/src/stratis_cli/_actions/_physical.py
+++ b/src/stratis_cli/_actions/_physical.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Miscellaneous physical actions.
 """
@@ -45,6 +44,7 @@ def state_val_to_string(val):
     except IndexError:
         return UNKNOWN_VALUE_MARKER
 
+
 def tier_val_to_string(val):
     """
     Convert a blockdev tier enumerated value to a string.
@@ -54,6 +54,7 @@ def tier_val_to_string(val):
         return states[val]
     except IndexError:
         return UNKNOWN_VALUE_MARKER
+
 
 class PhysicalActions(object):
     """
@@ -68,32 +69,25 @@ class PhysicalActions(object):
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (parent_pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.pool_name},
-           unique=True
-        )
-        modevs = [MODev(info) for _, info in devs(
-            managed_objects,
-            props={"Pool": parent_pool_object_path},
-        )]
-        tables = [
-            [
-                modev.Devnode(),
-                str(Range(modev.TotalPhysicalSize(), SECTOR_SIZE)),
-                state_val_to_string(modev.State()),
-                tier_val_to_string(modev.Tier()),
-            ] for modev in modevs
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
+        modevs = [
+            MODev(info) for _, info in devs(
+                managed_objects,
+                props={"Pool": parent_pool_object_path},
+            )
         ]
-        print_table(
-            [
-                "Device Node",
-                "Physical Size",
-                "State",
-                "Tier",
-            ],
-            sorted(tables, key=lambda entry: entry[0]),
-            ['<', '>', '>', '>']
-        )
+        tables = [[
+            modev.Devnode(),
+            str(Range(modev.TotalPhysicalSize(), SECTOR_SIZE)),
+            state_val_to_string(modev.State()),
+            tier_val_to_string(modev.Tier()),
+        ] for modev in modevs]
+        print_table([
+            "Device Node",
+            "Physical Size",
+            "State",
+            "Tier",
+        ], sorted(tables, key=lambda entry: entry[0]), ['<', '>', '>', '>'])
 
         return
 
@@ -105,15 +99,13 @@ class PhysicalActions(object):
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.pool_name},
-           unique=True
-        )
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
 
         (_, rc, message) = Pool.Methods.AddDataDevs(
-           get_object(pool_object_path),
-           {'force': namespace.force, 'devices': namespace.device}
-        )
+            get_object(pool_object_path), {
+                'force': namespace.force,
+                'devices': namespace.device
+            })
         if rc != StratisdErrors.OK:
             raise StratisCliRuntimeError(rc, message)
         return
@@ -126,15 +118,13 @@ class PhysicalActions(object):
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.pool_name},
-           unique=True
-        )
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
 
         (_, rc, message) = Pool.Methods.AddCacheDevs(
-           get_object(pool_object_path),
-           {'force': namespace.force, 'devices': namespace.device}
-        )
+            get_object(pool_object_path), {
+                'force': namespace.force,
+                'devices': namespace.device
+            })
         if rc != StratisdErrors.OK:
             raise StratisCliRuntimeError(rc, message)
         return

--- a/src/stratis_cli/_actions/_stratis.py
+++ b/src/stratis_cli/_actions/_stratis.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Miscellaneous actions about stratis.
 """

--- a/src/stratis_cli/_actions/_top.py
+++ b/src/stratis_cli/_actions/_top.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Miscellaneous top-level actions.
 """
@@ -50,14 +49,12 @@ class TopActions(object):
         proxy = get_object(TOP_OBJECT)
 
         (_, rc, message) = Manager.Methods.CreatePool(
-           proxy,
-           {
-              'name': namespace.pool_name,
-              'redundancy': (True, 0),
-              'force': namespace.force,
-              'devices': namespace.blockdevs
-           }
-        )
+            proxy, {
+                'name': namespace.pool_name,
+                'redundancy': (True, 0),
+                'force': namespace.force,
+                'devices': namespace.blockdevs
+            })
 
         if rc != StratisdErrors.OK:
             raise StratisCliRuntimeError(rc, message)
@@ -75,22 +72,14 @@ class TopActions(object):
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         mopools = (MOPool(info) for _, info in pools(managed_objects))
-        tables = [
-           [
-              mopool.Name(),
-              str(Range(mopool.TotalPhysicalSize(), SECTOR_SIZE)),
-              str(Range(mopool.TotalPhysicalUsed(), SECTOR_SIZE)),
-           ] for mopool in mopools
-        ]
-        print_table(
-           [
-              'Name',
-              'Total Physical Size',
-              'Total Physical Used'
-           ],
-           sorted(tables, key=lambda entry: entry[0]),
-           ['<', '>', '>']
-        )
+        tables = [[
+            mopool.Name(),
+            str(Range(mopool.TotalPhysicalSize(), SECTOR_SIZE)),
+            str(Range(mopool.TotalPhysicalUsed(), SECTOR_SIZE)),
+        ] for mopool in mopools]
+        print_table(['Name', 'Total Physical Size', 'Total Physical Used'],
+                    sorted(tables, key=lambda entry: entry[0]),
+                    ['<', '>', '>'])
 
         return
 
@@ -106,10 +95,7 @@ class TopActions(object):
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.pool_name},
-           unique=True
-        )
+            managed_objects, props={'Name': namespace.pool_name}, unique=True)
 
         (_, rc, message) = \
            Manager.Methods.DestroyPool(proxy, {'pool': pool_object_path})
@@ -127,15 +113,10 @@ class TopActions(object):
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = pools(
-           managed_objects,
-           props={'Name': namespace.current},
-           unique=True
-        )
+            managed_objects, props={'Name': namespace.current}, unique=True)
 
         (_, rc, message) = Pool.Methods.SetName(
-           get_object(pool_object_path),
-           {'name': namespace.new}
-        )
+            get_object(pool_object_path), {'name': namespace.new})
 
         if rc != StratisdErrors.OK:
             raise StratisCliRuntimeError(rc, message)

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Error heirarchy for stratis cli.
 """
+
 
 class StratisCliError(Exception):
     """
@@ -40,7 +40,7 @@ class StratisCliDbusLookupError(StratisCliError):
         self._interface = interface
         self._spec = spec
 
-    def __str__(self): # pragma: no cover
+    def __str__(self):  # pragma: no cover
         return "No object path found for interface %s and spec %s" % \
            (self._interface, self._spec)
 
@@ -64,7 +64,7 @@ class StratisCliValueError(StratisCliError):
         self._param = param
         self._msg = msg
 
-    def __str__(self): # pragma: no cover
+    def __str__(self):  # pragma: no cover
         if self._msg:
             fmt_str = self._FMT_STR + ": %s"
             return fmt_str % (self._value, self._param, self._msg)
@@ -78,17 +78,20 @@ class StratisCliValueUnimplementedError(StratisCliValueError):
     """
     pass
 
+
 class StratisCliUnimplementedError(StratisCliError):
     """
     Raised if a method is temporarily unimplemented.
     """
     pass
 
+
 class StratisCliKnownBugError(StratisCliError):
     """
     Raised if a method is unimplemented due to a bug.
     """
     pass
+
 
 class StratisCliRuntimeError(StratisCliError):
     """
@@ -108,6 +111,7 @@ class StratisCliRuntimeError(StratisCliError):
 
     def __str__(self):
         return "%s: %s" % (self.rc, self.message)
+
 
 class StratisCliImpossibleError(StratisCliError):
     """

--- a/src/stratis_cli/_main.py
+++ b/src/stratis_cli/_main.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Highest level runner.
 """
@@ -23,6 +22,7 @@ from dbus_python_client_gen import DPClientRuntimeError
 
 from ._errors import StratisCliError
 from ._parser import gen_parser
+
 
 def run():
     """

--- a/src/stratis_cli/_parser/__init__.py
+++ b/src/stratis_cli/_parser/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Top level of CLI.
 """

--- a/src/stratis_cli/_parser/_logical.py
+++ b/src/stratis_cli/_parser/_logical.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Definition of filesystem actions to display in the CLI.
 """
@@ -23,70 +22,57 @@ LOGICAL_SUBCMDS = [
      dict(
          help='Create filesystems in a pool',
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='pool name',
-              )),
+             ('pool_name', dict(
+                 action='store',
+                 help='pool name',
+             )),
              ('fs_name',
               dict(
                   help='Create filesystems in this pool using the given names',
                   nargs='+',
               )),
          ],
-         func=LogicalActions.create_volumes
-     )),
-     ('snapshot',
+         func=LogicalActions.create_volumes)),
+    ('snapshot',
      dict(
          help='Snapshot the named filesystem in a pool',
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='pool name',
-              )),
-             ('origin_name',
-              dict(
-                  action='store',
-                  help='origin name',
-              )),
-             ('snapshot_name',
-              dict(
-                  action='store',
-                  help='snapshot name',
-              )),
+             ('pool_name', dict(
+                 action='store',
+                 help='pool name',
+             )),
+             ('origin_name', dict(
+                 action='store',
+                 help='origin name',
+             )),
+             ('snapshot_name', dict(
+                 action='store',
+                 help='snapshot name',
+             )),
          ],
-         func=LogicalActions.snapshot_filesystem
-     )),
+         func=LogicalActions.snapshot_filesystem)),
     ('list',
      dict(
          help="List filesystems",
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='Pool name'
-              )),
+             ('pool_name', dict(action='store', help='Pool name')),
          ],
-         func=LogicalActions.list_volumes
-     )),
+         func=LogicalActions.list_volumes)),
     ('destroy',
      dict(
          help='Destroy filesystems in a pool',
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='pool name',
-              )),
+             ('pool_name', dict(
+                 action='store',
+                 help='pool name',
+             )),
              ('fs_name',
               dict(
                   help='Destroy the named filesystems in this pool',
                   nargs='+',
               )),
          ],
-         func=LogicalActions.destroy_volumes
-     )),
+         func=LogicalActions.destroy_volumes)),
     ('rename',
      dict(
          help='Rename a filesystem',
@@ -109,5 +95,4 @@ LOGICAL_SUBCMDS = [
          ],
          func=LogicalActions.rename_fs,
      )),
-
 ]

--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Top level parser for Stratis CLI.
 """
-
 
 import argparse
 
@@ -30,6 +28,7 @@ from ._pool import POOL_SUBCMDS
 # pylint: disable=undefined-variable
 PRINT_HELP = lambda parser: lambda _: parser.print_help()
 
+
 def add_args(parser, args=None):
     """
     Call subcommand.add_argument() based on args list.
@@ -38,12 +37,14 @@ def add_args(parser, args=None):
         for name, arg in args:
             parser.add_argument(name, **arg)
 
+
 def add_subcommand(subparser, cmd):
     """
     Add subcommand to a parser based on a subcommand dict.
     """
     name, info = cmd
-    parser = subparser.add_parser(name, help=info['help'], aliases=info.get('aliases', []))
+    parser = subparser.add_parser(
+        name, help=info['help'], aliases=info.get('aliases', []))
 
     subcmds = info.get('subcmds')
     if subcmds is not None:
@@ -54,6 +55,7 @@ def add_subcommand(subparser, cmd):
     add_args(parser, info.get('args', []))
 
     parser.set_defaults(func=info.get('func', PRINT_HELP(parser)))
+
 
 DAEMON_SUBCMDS = [
     ('redundancy',
@@ -69,11 +71,10 @@ DAEMON_SUBCMDS = [
 ]
 
 ROOT_SUBCOMMANDS = [
-    ('pool',
-     dict(
-         help="Perform General Pool Actions",
-         subcmds=POOL_SUBCMDS,
-     )),
+    ('pool', dict(
+        help="Perform General Pool Actions",
+        subcmds=POOL_SUBCMDS,
+    )),
     ('blockdev',
      dict(
          help="Commands related to block devices that make up the pool",
@@ -85,11 +86,10 @@ ROOT_SUBCOMMANDS = [
          help="Commands related to filesystems allocated from a pool",
          subcmds=LOGICAL_SUBCMDS,
      )),
-    ('daemon',
-     dict(
-         help="Stratis daemon information",
-         subcmds=DAEMON_SUBCMDS,
-     )),
+    ('daemon', dict(
+        help="Stratis daemon information",
+        subcmds=DAEMON_SUBCMDS,
+    )),
 ]
 
 GEN_ARGS = [
@@ -100,6 +100,7 @@ GEN_ARGS = [
      )),
 ]
 
+
 def gen_parser():
     """
     Make the parser.
@@ -108,16 +109,10 @@ def gen_parser():
     :rtype: ArgumentParser
     """
     parser = argparse.ArgumentParser(
-       description="Stratis Storage Manager",
-       prog='stratis'
-    )
+        description="Stratis Storage Manager", prog='stratis')
 
     # version is special, it has explicit support in argparse
-    parser.add_argument(
-       '--version',
-       action='version',
-       version=__version__
-    )
+    parser.add_argument('--version', action='version', version=__version__)
 
     add_args(parser, GEN_ARGS)
 

--- a/src/stratis_cli/_parser/_physical.py
+++ b/src/stratis_cli/_parser/_physical.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Definition of block device actions to display in the CLI.
 """
@@ -21,62 +20,52 @@ from .._actions import PhysicalActions
 PHYSICAL_SUBCMDS = [
     ('add-data',
      dict(
-         help="Add one or more blockdevs to an existing pool for use as data storage",
+         help=
+         "Add one or more blockdevs to an existing pool for use as data storage",
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='Pool name',
-              )),
+             ('pool_name', dict(
+                 action='store',
+                 help='Pool name',
+             )),
              ('device',
               dict(
                   help='Block devices to add to the pool',
                   metavar='blockdev',
-                  nargs='+'
-              )),
+                  nargs='+')),
              ('--force',
               dict(
                   action='store_true',
                   default=False,
-                  help="Use devices even if they appear to contain existing data"
-              )),
+                  help=
+                  "Use devices even if they appear to contain existing data")),
          ],
-         func=PhysicalActions.add_data_device
-     )),
+         func=PhysicalActions.add_data_device)),
     ('add-cache',
      dict(
          help="Add one or more blockdevs to an existing pool for use as cache",
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='Pool name',
-              )),
+             ('pool_name', dict(
+                 action='store',
+                 help='Pool name',
+             )),
              ('device',
               dict(
                   help='Block devices to add to the pool as cache',
                   metavar='blockdev',
-                  nargs='+'
-              )),
+                  nargs='+')),
              ('--force',
               dict(
                   action='store_true',
                   default=False,
-                  help="Use devices even if they appear to contain existing data"
-              )),
+                  help=
+                  "Use devices even if they appear to contain existing data")),
          ],
-         func=PhysicalActions.add_cache_device
-     )),
+         func=PhysicalActions.add_cache_device)),
     ('list',
      dict(
          help="List information about blockdevs in the pool",
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='Pool name'
-              )),
+             ('pool_name', dict(action='store', help='Pool name')),
          ],
-         func=PhysicalActions.list_pool
-     )),
+         func=PhysicalActions.list_pool)),
 ]

--- a/src/stratis_cli/_parser/_pool.py
+++ b/src/stratis_cli/_parser/_pool.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Definition of pool actions to display in the CLI.
 """
@@ -23,11 +22,10 @@ POOL_SUBCMDS = [
      dict(
          help='Create a pool',
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='Name of new pool',
-              )),
+             ('pool_name', dict(
+                 action='store',
+                 help='Name of new pool',
+             )),
              ('blockdevs',
               dict(
                   help='Create the pool using these block devs',
@@ -59,11 +57,10 @@ POOL_SUBCMDS = [
      dict(
          help='Destroy a pool',
          args=[
-             ('pool_name',
-              dict(
-                  action='store',
-                  help='pool name',
-              )),
+             ('pool_name', dict(
+                 action='store',
+                 help='pool name',
+             )),
          ],
          func=TopActions.destroy_pool,
      )),
@@ -71,16 +68,14 @@ POOL_SUBCMDS = [
      dict(
          help='Rename a pool',
          args=[
-             ('current',
-              dict(
-                  action='store',
-                  help='Current pool name',
-              )),
-             ('new',
-              dict(
-                  action='store',
-                  help='New pool name',
-              )),
+             ('current', dict(
+                 action='store',
+                 help='Current pool name',
+             )),
+             ('new', dict(
+                 action='store',
+                 help='New pool name',
+             )),
          ],
          func=TopActions.rename_pool,
      )),

--- a/src/stratis_cli/_stratisd_constants.py
+++ b/src/stratis_cli/_stratisd_constants.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Stratisd error classes.
 """

--- a/src/stratis_cli/_version.py
+++ b/src/stratis_cli/_version.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
     Version information.
 

--- a/tests/_misc.py
+++ b/tests/_misc.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Miscellaneous methods to support testing.
 """
@@ -40,12 +39,8 @@ def _device_list(minimum):
     :param int minimum: the minimum number of devices, must be at least 0
     """
     return strategies.lists(
-       strategies.text(
-          alphabet=string.ascii_letters + "/",
-          min_size=1
-       ),
-       min_size=minimum
-    )
+        strategies.text(alphabet=string.ascii_letters + "/", min_size=1),
+        min_size=minimum)
 
 
 class ServiceABC(abc.ABC):
@@ -67,6 +62,7 @@ class ServiceABC(abc.ABC):
         # pylint: disable=no-member
         self._stratisd.terminate()
         self._stratisd.wait()
+
 
 class ServiceR(ServiceABC):
     """

--- a/tests/integration/logical/test_create.py
+++ b/tests/integration/logical/test_create.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'create'.
 """
@@ -19,22 +18,20 @@ Test 'create'.
 import time
 import unittest
 
-
 from stratis_cli._errors import StratisCliRuntimeError
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from stratis_cli._stratisd_constants import StratisdErrors
 
-
 from .._misc import _device_list
 from .._misc import RUNNER
 from .._misc import Service
 
-
 _DEVICE_STRATEGY = _device_list(1)
 
 
-@unittest.skip("Temporarily unable to create multiple filesystems at same time")
+@unittest.skip(
+    "Temporarily unable to create multiple filesystems at same time")
 class CreateTestCase(unittest.TestCase):
     """
     Test creating a volume w/out a pool.
@@ -66,7 +63,8 @@ class CreateTestCase(unittest.TestCase):
             RUNNER(command_line)
 
 
-@unittest.skip("Temporarily unable to create multiple filesystems at same time")
+@unittest.skip(
+    "Temporarily unable to create multiple filesystems at same time")
 class Create2TestCase(unittest.TestCase):
     """
     Test creating a volume w/ a pool.
@@ -100,7 +98,8 @@ class Create2TestCase(unittest.TestCase):
         RUNNER(command_line)
 
 
-@unittest.skip("Temporarily unable to create multiple filesystems at same time")
+@unittest.skip(
+    "Temporarily unable to create multiple filesystems at same time")
 class Create3TestCase(unittest.TestCase):
     """
     Test creating a volume w/ a pool when volume of same name already exists.

--- a/tests/integration/logical/test_destroy.py
+++ b/tests/integration/logical/test_destroy.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'destroy'.
 """
@@ -28,8 +27,8 @@ from .._misc import Service
 _DEVICE_STRATEGY = _device_list(1)
 
 
-
-@unittest.skip("Temporarily unable to create multiple filesystems at same time")
+@unittest.skip(
+    "Temporarily unable to create multiple filesystems at same time")
 class DestroyTestCase(unittest.TestCase):
     """
     Test destroying a volume when the pool does not exist. In this case,
@@ -62,7 +61,8 @@ class DestroyTestCase(unittest.TestCase):
             RUNNER(command_line)
 
 
-@unittest.skip("Temporarily unable to create multiple filesystems at same time")
+@unittest.skip(
+    "Temporarily unable to create multiple filesystems at same time")
 class Destroy2TestCase(unittest.TestCase):
     """
     Test destroying a volume when the pool does exist but the volume does not.
@@ -98,7 +98,8 @@ class Destroy2TestCase(unittest.TestCase):
         RUNNER(command_line)
 
 
-@unittest.skip("Temporarily unable to create multiple filesystems at same time")
+@unittest.skip(
+    "Temporarily unable to create multiple filesystems at same time")
 class Destroy3TestCase(unittest.TestCase):
     """
     Test destroying a volume when the pool does exist and the volume does as
@@ -120,7 +121,8 @@ class Destroy3TestCase(unittest.TestCase):
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
-        command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLNAMES
+        command_line = ['filesystem', 'create', self._POOLNAME
+                        ] + self._VOLNAMES
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'create'.
 """
@@ -90,8 +89,8 @@ class List2TestCase(unittest.TestCase):
         RUNNER(command_line)
 
 
-
-@unittest.skip("Temporarily unable to create multiple filesystems at same time")
+@unittest.skip(
+    "Temporarily unable to create multiple filesystems at same time")
 class List3TestCase(unittest.TestCase):
     """
     Test listing volumes in an existing pool with some volumes.

--- a/tests/integration/logical/test_snapshot.py
+++ b/tests/integration/logical/test_snapshot.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'snapshot'.
 """
@@ -24,7 +23,6 @@ from stratis_cli._errors import StratisCliDbusLookupError
 from .._misc import _device_list
 from .._misc import RUNNER
 from .._misc import Service
-
 
 _DEVICE_STRATEGY = _device_list(1)
 
@@ -46,7 +44,8 @@ class SnapshotTestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = ['pool', 'create', self._POOLNAME] + _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME
+                        ] + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
         command_line = ['filesystem', 'create', self._POOLNAME, self._FSNAME]
         RUNNER(command_line)
@@ -61,8 +60,11 @@ class SnapshotTestCase(unittest.TestCase):
         """
         Creation of the snapshot should succeed since origin pool/filesytem is available.
         """
-        command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
+        command_line = self._MENU + [
+            self._POOLNAME, self._FSNAME, self._SNAPNAME
+        ]
         RUNNER(command_line)
+
 
 class Snapshot1TestCase(unittest.TestCase):
     """
@@ -91,9 +93,12 @@ class Snapshot1TestCase(unittest.TestCase):
         """
         Creation of the snapshot must fail since specified pool does not exist.
         """
-        command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
+        command_line = self._MENU + [
+            self._POOLNAME, self._FSNAME, self._SNAPNAME
+        ]
         with self.assertRaises(StratisCliDbusLookupError):
             RUNNER(command_line)
+
 
 class Snapshot2TestCase(unittest.TestCase):
     """
@@ -111,7 +116,8 @@ class Snapshot2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = ['pool', 'create', self._POOLNAME] + _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME
+                        ] + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):
@@ -124,6 +130,8 @@ class Snapshot2TestCase(unittest.TestCase):
         """
         Creation of the snapshot must fail since filesystem does not exist.
         """
-        command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
+        command_line = self._MENU + [
+            self._POOLNAME, self._FSNAME, self._SNAPNAME
+        ]
         with self.assertRaises(StratisCliDbusLookupError):
             RUNNER(command_line)

--- a/tests/integration/physical/test_add.py
+++ b/tests/integration/physical/test_add.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'create'.
 """
@@ -34,7 +33,6 @@ class AddDataTestCase(unittest.TestCase):
     """
     _MENU = ['--propagate', 'blockdev', 'add-data']
     _POOLNAME = 'deadpool'
-
 
     def setUp(self):
         """
@@ -59,13 +57,13 @@ class AddDataTestCase(unittest.TestCase):
         with self.assertRaises(StratisCliDbusLookupError):
             RUNNER(command_line)
 
+
 class AddCacheTestCase(unittest.TestCase):
     """
     Test adding devices to a non-existant pool.
     """
     _MENU = ['--propagate', 'blockdev', 'add-cache']
     _POOLNAME = 'deadpool'
-
 
     def setUp(self):
         """

--- a/tests/integration/physical/test_list.py
+++ b/tests/integration/physical/test_list.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'create'.
 """

--- a/tests/integration/pool/test_create.py
+++ b/tests/integration/pool/test_create.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'create'.
 """

--- a/tests/integration/pool/test_destroy.py
+++ b/tests/integration/pool/test_destroy.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'destroy'.
 """
@@ -19,17 +18,14 @@ Test 'destroy'.
 import time
 import unittest
 
-
 from stratis_cli._errors import StratisCliRuntimeError
 from stratis_cli._errors import StratisCliDbusLookupError
 
 from stratis_cli._stratisd_constants import StratisdErrors
 
-
 from .._misc import _device_list
 from .._misc import RUNNER
 from .._misc import Service
-
 
 _DEVICE_STRATEGY = _device_list(1)
 

--- a/tests/integration/pool/test_list.py
+++ b/tests/integration/pool/test_list.py
@@ -11,14 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'list'.
 """
 
 import time
 import unittest
-
 
 from .._misc import _device_list
 from .._misc import RUNNER

--- a/tests/integration/pool/test_rename.py
+++ b/tests/integration/pool/test_rename.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'rename'.
 """

--- a/tests/integration/test_stratis.py
+++ b/tests/integration/test_stratis.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Test 'stratisd'.
 """


### PR DESCRIPTION
Add two targets to the Makefile
  - fmt - auto-format the code to comply with PEP8 formatting standards
  - fmt-travis Invoked by CI to test if a PR is PEP8 compliant