### PR TITLE
Do not disable or ignore certain pylint errors

### DIFF
--- a/check.py
+++ b/check.py
@@ -11,7 +11,6 @@ arg_map = {
       "--disable=bad-continuation",
       "--disable=duplicate-code",
       "--disable=invalid-name",
-      "--ignored-classes=StratisdErrors",
       "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
    ],
    "tests" : [
@@ -20,7 +19,6 @@ arg_map = {
       "--disable=bad-continuation",
       "--disable=duplicate-code",
       "--disable=invalid-name",
-      "--disable=no-self-use",
       "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
    ],
    "bin/stratis" : [


### PR DESCRIPTION
StratisdErrors needed to be ignored back when it was autogenerated from
information on the stratisd D-Bus API. Now that it's defined in a
straightforward way, it does not need to be ignored.

I don't know why no-self-use was needed originally, but it is not needed
now, so it might as well go away.

Signed-off-by: mulhern <amulhern@redhat.com>