### PR TITLE
Remove unused errors

### DIFF
--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -45,54 +45,6 @@ class StratisCliDbusLookupError(StratisCliError):
            (self._interface, self._spec)
 
 
-class StratisCliValueError(StratisCliError):
-    """ Raised when a parameter has an unacceptable value.
-
-        May also be raised when the parameter has an unacceptable type.
-    """
-    _FMT_STR = "value '%s' for parameter %s is unacceptable"
-
-    def __init__(self, value, param, msg=None):
-        """ Initializer.
-
-            :param object value: the value
-            :param str param: the parameter
-            :param str msg: an explanatory message
-        """
-        # pylint: disable=super-init-not-called
-        self._value = value
-        self._param = param
-        self._msg = msg
-
-    def __str__(self):  # pragma: no cover
-        if self._msg:
-            fmt_str = self._FMT_STR + ": %s"
-            return fmt_str % (self._value, self._param, self._msg)
-        return self._FMT_STR % (self._value, self._param)
-
-
-class StratisCliValueUnimplementedError(StratisCliValueError):
-    """
-    Raised if a parameter is not intrinsically bad but functionality
-    is unimplemented for this value.
-    """
-    pass
-
-
-class StratisCliUnimplementedError(StratisCliError):
-    """
-    Raised if a method is temporarily unimplemented.
-    """
-    pass
-
-
-class StratisCliKnownBugError(StratisCliError):
-    """
-    Raised if a method is unimplemented due to a bug.
-    """
-    pass
-
-
 class StratisCliRuntimeError(StratisCliError):
     """
     Raised if there was a failure due to a RuntimeError.
@@ -111,10 +63,3 @@ class StratisCliRuntimeError(StratisCliError):
 
     def __str__(self):
         return "%s: %s" % (self.rc, self.message)
-
-
-class StratisCliImpossibleError(StratisCliError):
-    """
-    Raised when a should be logically impossible situation is encountered.
-    """
-    pass


### PR DESCRIPTION
Most of these are special marker errors from the time when the cli was
used as a way to talk about future funtionality of stratisd. Now that
stratisd is generally ahead of the CLI these can go away.

The StratisCliValueError wasn't useful and was replaced by more specific
errors a while ago.

Signed-off-by: mulhern <amulhern@redhat.com>