### PR TITLE
Do not disable bad-continuation warnings for pylint

### DIFF
--- a/check.py
+++ b/check.py
@@ -6,17 +6,17 @@ import sys
 
 arg_map = {
     "src/stratis_cli": [
-        "--reports=no", "--disable=I", "--disable=bad-continuation",
-        "--disable=duplicate-code", "--disable=invalid-name",
+        "--reports=no", "--disable=I", "--disable=duplicate-code",
+        "--disable=invalid-name",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
     ],
     "tests": [
-        "--reports=no", "--disable=I", "--disable=bad-continuation",
-        "--disable=duplicate-code", "--disable=invalid-name",
+        "--reports=no", "--disable=I", "--disable=duplicate-code",
+        "--disable=invalid-name",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
     ],
     "bin/stratis": [
-        "--reports=no", "--disable=bad-continuation",
+        "--reports=no",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
     ],
 }

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -92,18 +92,16 @@ class LogicalActions(object):
         (pool_object_path, _) = pools(
             managed_objects, props={'Name': namespace.pool_name}, unique=True)
         fs_object_paths = [
-           op for name in namespace.fs_name for (op, _) in \
-           filesystems(
-              managed_objects,
-              props={'Name': name, 'Pool': pool_object_path}
-           )
+            op for name in namespace.fs_name for (op, _) in filesystems(
+                managed_objects,
+                props={
+                    'Name': name,
+                    'Pool': pool_object_path
+                })
         ]
 
-        (_, rc, message) = \
-           Pool.Methods.DestroyFilesystems(
-              get_object(pool_object_path),
-              {'filesystems': fs_object_paths}
-           )
+        (_, rc, message) = Pool.Methods.DestroyFilesystems(
+            get_object(pool_object_path), {'filesystems': fs_object_paths})
 
         if rc != StratisdErrors.OK:
             raise StratisCliRuntimeError(rc, message)
@@ -130,12 +128,11 @@ class LogicalActions(object):
             },
             unique=True)
 
-        (_, rc, message) = \
-           Pool.Methods.SnapshotFilesystem(
-              get_object(pool_object_path),
-              {'origin': origin_fs_object_path,
-               'snapshot_name': namespace.snapshot_name}
-           )
+        (_, rc, message) = Pool.Methods.SnapshotFilesystem(
+            get_object(pool_object_path), {
+                'origin': origin_fs_object_path,
+                'snapshot_name': namespace.snapshot_name
+            })
 
         if rc != StratisdErrors.OK:
             raise StratisCliRuntimeError(rc, message)

--- a/tests/integration/logical/test_destroy.py
+++ b/tests/integration/logical/test_destroy.py
@@ -117,12 +117,12 @@ class Destroy3TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = ['pool', 'create', self._POOLNAME] \
-            + _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] + \
+                _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
-        command_line = ['filesystem', 'create', self._POOLNAME
-                        ] + self._VOLNAMES
+        command_line = ['filesystem', 'create', self._POOLNAME] + \
+                self._VOLNAMES
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/logical/test_snapshot.py
+++ b/tests/integration/logical/test_snapshot.py
@@ -44,8 +44,8 @@ class SnapshotTestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = ['pool', 'create', self._POOLNAME
-                        ] + _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] + \
+                _DEVICE_STRATEGY.example()
         RUNNER(command_line)
         command_line = ['filesystem', 'create', self._POOLNAME, self._FSNAME]
         RUNNER(command_line)
@@ -116,8 +116,8 @@ class Snapshot2TestCase(unittest.TestCase):
         self._service = Service()
         self._service.setUp()
         time.sleep(1)
-        command_line = ['pool', 'create', self._POOLNAME
-                        ] + _DEVICE_STRATEGY.example()
+        command_line = ['pool', 'create', self._POOLNAME] + \
+                _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
     def tearDown(self):


### PR DESCRIPTION
Make a few edits so that the code will satisfy both pylint and yapf.

bad-continuation was disabled by me so that I could use my own formatting
style. Now that we are using yapf there is no point, so might as well
just conform to both. I think the code looks slightly better this way.

Signed-off-by: mulhern <amulhern@redhat.com>