### PR TITLE
Do not include rc in StratisCliRuntimeError.__str__

### DIFF
--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -62,4 +62,4 @@ class StratisCliRuntimeError(StratisCliError):
         self.message = message
 
     def __str__(self):
-        return "%s: %s" % (self.rc, self.message)
+        return "%s" % self.message


### PR DESCRIPTION
This message is printed on the command-line when a call to stratisd fails
for a non-dbus-related reason. For example, when trying to create a pool
with a name that is already used by an existing pool.

The rc value is not decoded. I suppose it could be, but it seems like just
printing the message is likely to best convey what happened to the user.

Signed-off-by: Andy Grover <agrover@redhat.com>