### PR TITLE
Clean up unit tests a bit

### DIFF
--- a/tests/_misc.py
+++ b/tests/_misc.py
@@ -15,11 +15,11 @@
 Miscellaneous methods to support testing.
 """
 
-import abc
 import os
 import string
 import subprocess
 import sys
+import time
 
 from hypothesis import strategies
 
@@ -43,17 +43,17 @@ def _device_list(minimum):
         min_size=minimum)
 
 
-class ServiceABC(abc.ABC):
+class Service(object):
     """
-    Abstract base class of Service classes.
+    Handle starting and stopping the Rust service.
     """
 
-    @abc.abstractmethod
     def setUp(self):
         """
         Start the stratisd daemon with the simulator.
         """
-        raise NotImplementedError()
+        self._stratisd = subprocess.Popen([os.path.join(_STRATISD), '--sim'])
+        time.sleep(1)
 
     def tearDown(self):
         """
@@ -63,19 +63,5 @@ class ServiceABC(abc.ABC):
         self._stratisd.terminate()
         self._stratisd.wait()
 
-
-class ServiceR(ServiceABC):
-    """
-    Handle starting and stopping the Rust service.
-    """
-
-    def setUp(self):
-        try:
-            self._stratisd = subprocess.Popen([_STRATISD, '--sim'])
-        except FileNotFoundError as err:
-            sys.exit("stratisd executable not found: %s" % err)
-
-
-Service = ServiceR
 
 RUNNER = run()

--- a/tests/integration/logical/test_create.py
+++ b/tests/integration/logical/test_create.py
@@ -15,7 +15,6 @@
 Test 'create'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliRuntimeError
@@ -46,7 +45,6 @@ class CreateTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -79,7 +77,6 @@ class Create2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] \
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
@@ -114,7 +111,6 @@ class Create3TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] \
             +  _DEVICE_STRATEGY.example()
         RUNNER(command_line)

--- a/tests/integration/logical/test_destroy.py
+++ b/tests/integration/logical/test_destroy.py
@@ -15,7 +15,6 @@
 Test 'destroy'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliDbusLookupError
@@ -44,7 +43,6 @@ class DestroyTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -78,7 +76,6 @@ class Destroy2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] \
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
@@ -116,7 +113,6 @@ class Destroy3TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] + \
                 _DEVICE_STRATEGY.example()
         RUNNER(command_line)

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -15,7 +15,6 @@
 Test 'create'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliDbusLookupError
@@ -40,7 +39,6 @@ class ListTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -70,7 +68,6 @@ class List2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create'] + [self._POOLNAME] \
             +  _DEVICE_STRATEGY.example()
         RUNNER(command_line)
@@ -105,7 +102,6 @@ class List3TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] \
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)

--- a/tests/integration/logical/test_snapshot.py
+++ b/tests/integration/logical/test_snapshot.py
@@ -15,7 +15,6 @@
 Test 'snapshot'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliDbusLookupError
@@ -43,7 +42,6 @@ class SnapshotTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] + \
                 _DEVICE_STRATEGY.example()
         RUNNER(command_line)
@@ -81,7 +79,6 @@ class Snapshot1TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -115,7 +112,6 @@ class Snapshot2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] + \
                 _DEVICE_STRATEGY.example()
         RUNNER(command_line)

--- a/tests/integration/physical/test_add.py
+++ b/tests/integration/physical/test_add.py
@@ -15,7 +15,6 @@
 Test 'create'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliDbusLookupError
@@ -40,7 +39,6 @@ class AddDataTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -71,7 +69,6 @@ class AddCacheTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """

--- a/tests/integration/physical/test_list.py
+++ b/tests/integration/physical/test_list.py
@@ -15,7 +15,6 @@
 Test 'create'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliDbusLookupError
@@ -40,7 +39,6 @@ class ListTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -70,7 +68,6 @@ class List2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create'] + [self._POOLNAME] \
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)

--- a/tests/integration/pool/test_create.py
+++ b/tests/integration/pool/test_create.py
@@ -15,7 +15,6 @@
 Test 'create'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliRuntimeError
@@ -40,7 +39,6 @@ class CreateTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -71,7 +69,6 @@ class Create3TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] \
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)

--- a/tests/integration/pool/test_destroy.py
+++ b/tests/integration/pool/test_destroy.py
@@ -15,7 +15,6 @@
 Test 'destroy'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliRuntimeError
@@ -45,7 +44,6 @@ class Destroy1TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -75,7 +73,6 @@ class Destroy2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] \
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
@@ -108,7 +105,6 @@ class Destroy3TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
         command_line = ['pool', 'create', self._POOLNAME] \
             + _DEVICE_STRATEGY.example()

--- a/tests/integration/pool/test_list.py
+++ b/tests/integration/pool/test_list.py
@@ -15,7 +15,6 @@
 Test 'list'.
 """
 
-import time
 import unittest
 
 from .._misc import _device_list
@@ -37,7 +36,6 @@ class ListTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -66,7 +64,6 @@ class List2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] \
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)

--- a/tests/integration/pool/test_rename.py
+++ b/tests/integration/pool/test_rename.py
@@ -15,7 +15,6 @@
 Test 'rename'.
 """
 
-import time
 import unittest
 
 from stratis_cli._errors import StratisCliDbusLookupError
@@ -41,7 +40,6 @@ class Rename1TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """
@@ -80,7 +78,6 @@ class Rename2TestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
         command_line = ['pool', 'create', self._POOLNAME] \
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)

--- a/tests/integration/test_stratis.py
+++ b/tests/integration/test_stratis.py
@@ -15,7 +15,6 @@
 Test 'stratisd'.
 """
 
-import time
 import unittest
 
 import dbus
@@ -36,7 +35,6 @@ class StratisTestCase(unittest.TestCase):
         """
         self._service = Service()
         self._service.setUp()
-        time.sleep(1)
 
     def tearDown(self):
         """


### PR DESCRIPTION
Remove class heirarchy in __init__.py. There's no reason for it anymore,
since the C version is now obsolete.

Have Service.setUp() call time.sleep(). This is an improvement over having
it called after every call to Service.setup().

All these things have been done in stratisd's dbus-client tests already.

Signed-off-by: mulhern <amulhern@redhat.com>