### PR TITLE
Allow lint task to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ python: "3.4"
 branches:
     only: master
 
-env:
-    matrix:
-        - TASK=lint
-        - TASK=fmt-travis
+matrix:
+    allow_failures:
+        - env: TASK=lint
+    include:
+        - env: TASK=lint
+        - env: TASK=fmt-travis
 
 script: make -f Makefile $TASK


### PR DESCRIPTION
It requires dbus-python which has increased the version of dbus-1 which
it depends on from 1.6 to 1.8.  Travis's version of Ubuntu does not
currently supply that version.

Signed-off-by: mulhern <amulhern@redhat.com>