### PR TITLE
Pin dbus-python to 1.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ branches:
     only: master
 
 matrix:
-    allow_failures:
-        - env: TASK=lint
     include:
         - env: TASK=lint
         - env: TASK=fmt-travis

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=lint
 
 [testenv:lint]
 deps =
-    dbus-python
+    dbus-python==1.2.4
     hypothesis
     pylint
     pytest>=2.8


### PR DESCRIPTION
This allows running the lint test on Travis while Travis's version of
Ubuntu does not support libdbus v.1.8. This is the most recent available
version of dbus-python which is not the current, problematical one that
requires libdbus v.1.8. When Travis has upgraded sufficiently, this pin
can be dropped.

No longer allow lint task to be a failure.

Signed-off-by: mulhern <amulhern@redhat.com>