### PR TITLE
Update Python style remark

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,5 +86,5 @@ Internal Software Architecture
 
 Python Coding Style
 -------------------
-``stratis`` uses PEP-8 style, with the additional rule that continuation lines
-are indented 3 spaces.
+``stratis`` conforms to PEP-8 style guidelines as enforced by the ``yapf``
+formatting tool.


### PR DESCRIPTION
Because the code uses the yapf formatter, it should conform entirely to
PEP-8 style.

Signed-off-by: mulhern <amulhern@redhat.com>