### PR TITLE
Extend and improve interpretation of D-Bus errors

### DIFF
--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -74,24 +74,26 @@ def interpret_errors(errors):
     # TODO: This method is extremely rudimentary. It should not be extended
     # using exactly the structure it has now.
     try:
-        if isinstance(errors[1], AttributeError):
+        # Inspect top-most error after StratisCliActionError
+        error = errors[1]
+        if isinstance(error, AttributeError):
             import traceback
-            frame = traceback.extract_tb(errors[1].__traceback__)[-1]
+            frame = traceback.extract_tb(error.__traceback__)[-1]
             fmt_str = (
                 "Most likely there is an error in the source at line %d "
                 "in file %s. The text of the line is \"%s\".")
             return fmt_str % (frame.lineno, frame.filename, frame.line)
-        if isinstance(errors[1], dbus.exceptions.DBusException) and \
-            errors[1].get_dbus_name() == \
+        if isinstance(error, dbus.exceptions.DBusException) and \
+            error.get_dbus_name() == \
             'org.freedesktop.DBus.Error.ServiceUnknown':
             return "Most likely the Stratis daemon, stratisd, is not running."
-        if isinstance(errors[1], DbusClientUnknownSearchPropertiesError):
+        if isinstance(error, DbusClientUnknownSearchPropertiesError):
             return _STRATIS_CLI_BUG_MSG
-        if isinstance(errors[1], DbusClientMissingSearchPropertiesError):
+        if isinstance(error, DbusClientMissingSearchPropertiesError):
             return _DBUS_INTERFACE_MSG
-        if isinstance(errors[1], DbusClientMissingInterfaceError):
+        if isinstance(error, DbusClientMissingInterfaceError):
             return _STRATIS_CLI_BUG_MSG
-        if isinstance(errors[1], DbusClientMissingPropertyError):
+        if isinstance(error, DbusClientMissingPropertyError):
             return _DBUS_INTERFACE_MSG
 
         return None

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -83,10 +83,6 @@ def interpret_errors(errors):
                 "Most likely there is an error in the source at line %d "
                 "in file %s. The text of the line is \"%s\".")
             return fmt_str % (frame.lineno, frame.filename, frame.line)
-        if isinstance(error, dbus.exceptions.DBusException) and \
-            error.get_dbus_name() == \
-            'org.freedesktop.DBus.Error.ServiceUnknown':
-            return "Most likely the Stratis daemon, stratisd, is not running."
         if isinstance(error, DbusClientUnknownSearchPropertiesError):
             return _STRATIS_CLI_BUG_MSG
         if isinstance(error, DbusClientMissingSearchPropertiesError):
@@ -102,6 +98,10 @@ def interpret_errors(errors):
             error.get_dbus_name() == \
             'org.freedesktop.DBus.Error.AccessDenied':
             return "Most likely stratis has insufficient permissions for the action requested."
+        if isinstance(error, dbus.exceptions.DBusException) and \
+            error.get_dbus_name() == \
+            'org.freedesktop.DBus.Error.NameHasNoOwner':
+            return "Most likely the Stratis daemon, stratisd, is not running."
 
         return None
     # pylint: disable=broad-except

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -96,6 +96,13 @@ def interpret_errors(errors):
         if isinstance(error, DbusClientMissingPropertyError):
             return _DBUS_INTERFACE_MSG
 
+        # Inspect lowest error
+        error = errors[-1]
+        if isinstance(error, dbus.exceptions.DBusException) and \
+            error.get_dbus_name() == \
+            'org.freedesktop.DBus.Error.AccessDenied':
+            return "Most likely stratis has insufficient permissions for the action requested."
+
         return None
     # pylint: disable=broad-except
     except Exception:


### PR DESCRIPTION
Adds an interpretation for ```AccessDenied``` error. Triggers "Most likely the Stratis daemon, stratisd, is not running" message on ```NameHasNoOwner``` exception, rather than ```ServiceUnknown``` exception which is higher level and less specific.

Resolves: #164 .