### PR TITLE
Change 'stratis pool' and 'stratis blockdev' behavior

### DIFF
--- a/src/stratis_cli/_actions/_physical.py
+++ b/src/stratis_cli/_actions/_physical.py
@@ -73,7 +73,7 @@ class PhysicalActions():
 
         # If user specified a pool name we wil constrain output to that one
         # pool, else we will output all blockdevs.
-        if namespace.pool_name:
+        if vars(namespace).get("pool_name"):
             (parent_pool_object_path, _) = unique(
                 pools(props={
                     'Name': namespace.pool_name

--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -46,15 +46,20 @@ def add_subcommand(subparser, cmd):
     parser = subparser.add_parser(
         name, help=info['help'], aliases=info.get('aliases', []))
 
+    default_func = info.get('func', PRINT_HELP(parser))
+
     subcmds = info.get('subcmds')
     if subcmds is not None:
         subparsers = parser.add_subparsers(title='subcommands')
         for subcmd in subcmds:
             add_subcommand(subparsers, subcmd)
 
+            if subcmd[1].get("default", False) == True:
+                default_func = subcmd[1]['func']
+
     add_args(parser, info.get('args', []))
 
-    parser.set_defaults(func=info.get('func', PRINT_HELP(parser)))
+    parser.set_defaults(func=default_func)
 
 
 DAEMON_SUBCMDS = [

--- a/src/stratis_cli/_parser/_physical.py
+++ b/src/stratis_cli/_parser/_physical.py
@@ -68,5 +68,6 @@ PHYSICAL_SUBCMDS = [
              ('pool_name',
               dict(action='store', default=None, nargs="?", help='Pool name')),
          ],
-         func=PhysicalActions.list_pool)),
+         func=PhysicalActions.list_pool,
+         default=True)),
 ]

--- a/src/stratis_cli/_parser/_pool.py
+++ b/src/stratis_cli/_parser/_pool.py
@@ -52,6 +52,7 @@ POOL_SUBCMDS = [
          help="List pools",
          description="Lists Stratis pools that exist on the system",
          func=TopActions.list_pools,
+         default=True,
      )),
     ('destroy',
      dict(


### PR DESCRIPTION
Change from showing subcommand help to "list" behavior. Help is still available for subcommands by giving `--help`. This should make the default behavior a little friendlier.