### PR TITLE
Test listing blockdevs when no pool is specified

### DIFF
--- a/src/stratis_cli/_actions/_physical.py
+++ b/src/stratis_cli/_actions/_physical.py
@@ -73,7 +73,7 @@ class PhysicalActions():
 
         # If user specified a pool name we wil constrain output to that one
         # pool, else we will output all blockdevs.
-        if namespace.pool_name:
+        if namespace.pool_name is not None:
             (parent_pool_object_path, _) = unique(
                 pools(props={
                     'Name': namespace.pool_name

--- a/tests/integration/physical/test_list.py
+++ b/tests/integration/physical/test_list.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test 'create'.
+Test 'list'.
 """
 
 import unittest
@@ -57,6 +57,14 @@ class ListTestCase(unittest.TestCase):
         cause = context.exception.__cause__
         self.assertIsInstance(cause, StratisCliUniqueLookupError)
 
+    def testListEmpty(self):
+        """
+        Listing the devices should succeed without a pool name specified.
+        The list should be empty.
+        """
+        command_line = self._MENU
+        RUNNER(command_line)
+
 
 class List2TestCase(unittest.TestCase):
     """
@@ -86,4 +94,11 @@ class List2TestCase(unittest.TestCase):
         Listing the devices should succeed.
         """
         command_line = self._MENU + [self._POOLNAME]
+        RUNNER(command_line)
+
+    def testListEmpty(self):
+        """
+        Listing the devices should succeed without a pool name specified.
+        """
+        command_line = self._MENU
         RUNNER(command_line)


### PR DESCRIPTION
This also does an explicit comparison when checking whether there has been a pool name specified.