### PR TITLE
Enhance output of 'stratis fs list'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setuptools.setup(
         'dbus-client-gen>=0.3',
         'dbus-python-client-gen>=0.5',
         'justbytes==0.11',
+        'python-dateutil',
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -131,14 +131,23 @@ SPECS = {
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
+<property name="Created" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
 <property name="Devnode" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="MountPoints" type="as" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
 <property name="Name" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
 <property name="Pool" type="o" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="Used" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
 </property>
 <property name="Uuid" type="s" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -87,10 +87,9 @@ class LogicalActions():
             mofilesystem.Devnode(),
         ] for mofilesystem in mofilesystems]
 
-        print_table(
-            ['Pool Name', 'Name', 'Used', 'Created', 'Device'],
-            sorted(tables,
-                   key=lambda entry: entry[0]), ['<', '<', '<', '<', '<'])
+        print_table(['Pool Name', 'Name', 'Used', 'Created', 'Device'],
+                    sorted(tables, key=lambda entry: entry[0]),
+                    ['<', '<', '<', '<', '<'])
 
     @staticmethod
     def destroy_volumes(namespace):

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -17,8 +17,8 @@ Miscellaneous logical actions.
 
 from __future__ import print_function
 
-from justbytes import Range
 from dateutil import parser as date_parser
+from justbytes import Range
 
 from .._errors import StratisCliEngineError
 

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -17,6 +17,8 @@ Miscellaneous logical actions.
 
 from __future__ import print_function
 
+from justbytes import Range
+
 from .._errors import StratisCliEngineError
 
 from .._stratisd_constants import StratisdErrors
@@ -91,10 +93,11 @@ class LogicalActions():
         tables = [[
             path_to_name[mofilesystem.Pool()],
             mofilesystem.Name(),
+            str(Range(mofilesystem.Used(), 1)),
         ] for mofilesystem in mofilesystems]
 
-        print_table(['Pool Name', 'Name'], sorted(tables, key=lambda entry: entry[0]),
-                    ['<', '<'])
+        print_table(['Pool Name', 'Name', 'Used'], sorted(tables, key=lambda entry: entry[0]),
+                    ['<', '<', '>'])
 
     @staticmethod
     def destroy_volumes(namespace):

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -81,7 +81,7 @@ class LogicalActions():
         tables = [[
             path_to_name[mofilesystem.Pool()],
             mofilesystem.Name(),
-            str(Range(mofilesystem.Used(), 1)),
+            str(Range(mofilesystem.Used())),
             date_parser.parse(mofilesystem.Created()).astimezone().strftime(
                 "%b %d %Y %H:%M"),
             mofilesystem.Devnode(),

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -18,6 +18,7 @@ Miscellaneous logical actions.
 from __future__ import print_function
 
 from justbytes import Range
+from dateutil import parser as date_parser
 
 from .._errors import StratisCliEngineError
 
@@ -94,10 +95,11 @@ class LogicalActions():
             path_to_name[mofilesystem.Pool()],
             mofilesystem.Name(),
             str(Range(mofilesystem.Used(), 1)),
+            date_parser.parse(mofilesystem.Created()).astimezone().strftime("%b %d %Y %H:%M"),
         ] for mofilesystem in mofilesystems]
 
-        print_table(['Pool Name', 'Name', 'Used'], sorted(tables, key=lambda entry: entry[0]),
-                    ['<', '<', '>'])
+        print_table(['Pool Name', 'Name', 'Used', 'Created'], sorted(tables, key=lambda entry: entry[0]),
+                    ['<', '<', '>', '>'])
 
     @staticmethod
     def destroy_volumes(namespace):

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -27,7 +27,6 @@ from .._stratisd_constants import StratisdErrors
 from ._connection import get_object
 from ._constants import TOP_OBJECT
 from ._data import MOFilesystem
-from ._data import MOPool
 from ._data import ObjectManager
 from ._data import Pool
 from ._data import Filesystem
@@ -35,6 +34,7 @@ from ._data import filesystems
 from ._data import pools
 from ._data import unique
 from ._formatting import print_table
+from ._util import get_pools
 
 
 class LogicalActions():
@@ -70,19 +70,8 @@ class LogicalActions():
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
 
-        if getattr(namespace, "pool_name", None) is not None:
-            (parent_pool_object_path, _) = unique(
-                pools(props={
-                    'Name': namespace.pool_name
-                }).search(managed_objects))
-
-            properties = {"Pool": parent_pool_object_path}
-            path_to_name = {parent_pool_object_path: namespace.pool_name}
-        else:
-            properties = {}
-            path_to_name = dict(
-                (path, MOPool(info).Name())
-                for path, info in pools().search(managed_objects))
+        (properties, path_to_name) = get_pools(namespace, "pool_name",
+                                               managed_objects)
 
         mofilesystems = [
             MOFilesystem(info) for _, info in filesystems(props=properties)

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -96,10 +96,12 @@ class LogicalActions():
             mofilesystem.Name(),
             str(Range(mofilesystem.Used(), 1)),
             date_parser.parse(mofilesystem.Created()).astimezone().strftime("%b %d %Y %H:%M"),
+            mofilesystem.Devnode(),
+            ", ".join(mofilesystem.MountPoints()),
         ] for mofilesystem in mofilesystems]
 
-        print_table(['Pool Name', 'Name', 'Used', 'Created'], sorted(tables, key=lambda entry: entry[0]),
-                    ['<', '<', '>', '>'])
+        print_table(['Pool Name', 'Name', 'Used', 'Created', 'Device', 'Mount Points'], sorted(tables, key=lambda entry: entry[0]),
+                    ['<', '<', '<', '<', '<', '<'])
 
     @staticmethod
     def destroy_volumes(namespace):

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -85,13 +85,12 @@ class LogicalActions():
             date_parser.parse(mofilesystem.Created()).astimezone().strftime(
                 "%b %d %Y %H:%M"),
             mofilesystem.Devnode(),
-            ", ".join(mofilesystem.MountPoints()),
         ] for mofilesystem in mofilesystems]
 
         print_table(
-            ['Pool Name', 'Name', 'Used', 'Created', 'Device', 'Mount Points'],
+            ['Pool Name', 'Name', 'Used', 'Created', 'Device'],
             sorted(tables,
-                   key=lambda entry: entry[0]), ['<', '<', '<', '<', '<', '<'])
+                   key=lambda entry: entry[0]), ['<', '<', '<', '<', '<'])
 
     @staticmethod
     def destroy_volumes(namespace):

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -70,7 +70,6 @@ class LogicalActions():
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
 
-
         if getattr(namespace, "pool_name", None) is not None:
             (parent_pool_object_path, _) = unique(
                 pools(props={
@@ -85,23 +84,25 @@ class LogicalActions():
                 (path, MOPool(info).Name())
                 for path, info in pools().search(managed_objects))
 
-
         mofilesystems = [
-            MOFilesystem(info)
-            for _, info in filesystems(props=properties, ).search(managed_objects)
+            MOFilesystem(info) for _, info in filesystems(props=properties)
+            .search(managed_objects)
         ]
 
         tables = [[
             path_to_name[mofilesystem.Pool()],
             mofilesystem.Name(),
             str(Range(mofilesystem.Used(), 1)),
-            date_parser.parse(mofilesystem.Created()).astimezone().strftime("%b %d %Y %H:%M"),
+            date_parser.parse(mofilesystem.Created()).astimezone().strftime(
+                "%b %d %Y %H:%M"),
             mofilesystem.Devnode(),
             ", ".join(mofilesystem.MountPoints()),
         ] for mofilesystem in mofilesystems]
 
-        print_table(['Pool Name', 'Name', 'Used', 'Created', 'Device', 'Mount Points'], sorted(tables, key=lambda entry: entry[0]),
-                    ['<', '<', '<', '<', '<', '<'])
+        print_table(
+            ['Pool Name', 'Name', 'Used', 'Created', 'Device', 'Mount Points'],
+            sorted(tables,
+                   key=lambda entry: entry[0]), ['<', '<', '<', '<', '<', '<'])
 
     @staticmethod
     def destroy_volumes(namespace):

--- a/src/stratis_cli/_actions/_physical.py
+++ b/src/stratis_cli/_actions/_physical.py
@@ -28,12 +28,12 @@ from ._constants import TOP_OBJECT
 from ._constants import UNKNOWN_VALUE_MARKER
 from ._data import devs
 from ._data import MODev
-from ._data import MOPool
 from ._data import ObjectManager
 from ._data import Pool
 from ._data import pools
 from ._data import unique
 from ._formatting import print_table
+from ._util import get_pools
 
 
 def state_val_to_string(val):
@@ -72,19 +72,8 @@ class PhysicalActions():
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
 
-        if getattr(namespace, "pool_name", None) is not None:
-            (parent_pool_object_path, _) = unique(
-                pools(props={
-                    'Name': namespace.pool_name
-                }).search(managed_objects))
-
-            properties = {"Pool": parent_pool_object_path}
-            path_to_name = {parent_pool_object_path: namespace.pool_name}
-        else:
-            properties = {}
-            path_to_name = dict(
-                (path, MOPool(info).Name())
-                for path, info in pools().search(managed_objects))
+        (properties, path_to_name) = get_pools(namespace, "pool_name",
+                                               managed_objects)
 
         modevs = [
             MODev(info)

--- a/src/stratis_cli/_actions/_util.py
+++ b/src/stratis_cli/_actions/_util.py
@@ -1,0 +1,50 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Shared utilities.
+"""
+
+from __future__ import print_function
+
+from ._data import MOPool
+from ._data import pools
+from ._data import unique
+
+
+def get_pools(namespace, pool_name_key, managed_objects):
+    """
+    Get pools specified by namespace and designated pool_name_key.
+    If no pool is specified in namespace, get all pools.
+
+    :param namespace: the parser namespace
+    :param str pool_name_key: the key in the namespace for the pool name
+    :param managed_objects: the result of a GetManagedObjects call
+
+    :returns: lookup properties and a map from pool object path to name
+    :rtype: dict * dict
+    """
+    if getattr(namespace, pool_name_key, None) is not None:
+        (parent_pool_object_path, _) = unique(
+            pools(props={
+                'Name': namespace.pool_name
+            }).search(managed_objects))
+
+        properties = {"Pool": parent_pool_object_path}
+        path_to_name = {parent_pool_object_path: namespace.pool_name}
+    else:
+        properties = {}
+        path_to_name = dict((path, MOPool(info).Name())
+                            for path, info in pools().search(managed_objects))
+
+    return (properties, path_to_name)

--- a/src/stratis_cli/_parser/_logical.py
+++ b/src/stratis_cli/_parser/_logical.py
@@ -55,7 +55,8 @@ LOGICAL_SUBCMDS = [
      dict(
          help="List filesystems",
          args=[
-             ('pool_name', dict(action='store', help='Pool name')),
+             ('pool_name',
+              dict(action='store', default=None, nargs="?", help='Pool name')),
          ],
          func=LogicalActions.list_volumes)),
     ('destroy',

--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -17,8 +17,8 @@ Top level parser for Stratis CLI.
 
 import argparse
 
-from .._actions import PhysicalActions
 from .._actions import LogicalActions
+from .._actions import PhysicalActions
 from .._actions import StratisActions
 from .._actions import TopActions
 

--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -18,6 +18,7 @@ Top level parser for Stratis CLI.
 import argparse
 
 from .._actions import PhysicalActions
+from .._actions import LogicalActions
 from .._actions import StratisActions
 from .._actions import TopActions
 
@@ -90,6 +91,7 @@ ROOT_SUBCOMMANDS = [
          aliases=['fs'],
          help="Commands related to filesystems allocated from a pool",
          subcmds=LOGICAL_SUBCMDS,
+         func=LogicalActions.list_volumes,
      )),
     ('daemon', dict(
         help="Stratis daemon information",

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -124,6 +124,7 @@ class List3TestCase(unittest.TestCase):
         command_line = self._MENU + [self._POOLNAME]
         RUNNER(command_line)
 
+
 class List4TestCase(unittest.TestCase):
     """
     Test listing volumes in an existing pool with some volumes.
@@ -142,11 +143,14 @@ class List4TestCase(unittest.TestCase):
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
-        command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLUMES[0]
+        command_line = ['filesystem', 'create', self._POOLNAME
+                        ] + self._VOLUMES[0]
         RUNNER(command_line)
-        command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLUMES[1]
+        command_line = ['filesystem', 'create', self._POOLNAME
+                        ] + self._VOLUMES[1]
         RUNNER(command_line)
-        command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLUMES[2]
+        command_line = ['filesystem', 'create', self._POOLNAME
+                        ] + self._VOLUMES[2]
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -129,7 +129,6 @@ class List4TestCase(unittest.TestCase):
     """
     Test listing volumes in an existing pool with some volumes.
     """
-    _MENU = ['--propagate', 'filesystem', 'list']
     _POOLNAME = 'deadpool'
     _VOLUMES = ['livery', 'liberty', 'library']
 
@@ -166,7 +165,7 @@ class List4TestCase(unittest.TestCase):
         """
         Listing multiple volumes in a non-empty pool should succeed.
         """
-        command_line = self._MENU + [self._POOLNAME]
+        command_line = ['--propagate', 'filesystem', 'list', self._POOLNAME]
         RUNNER(command_line)
 
         # Also should work when no pool name is given

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -123,3 +123,49 @@ class List3TestCase(unittest.TestCase):
         """
         command_line = self._MENU + [self._POOLNAME]
         RUNNER(command_line)
+
+class List4TestCase(unittest.TestCase):
+    """
+    Test listing volumes in an existing pool with some volumes.
+    """
+    _MENU = ['--propagate', 'filesystem', 'list']
+    _POOLNAME = 'deadpool'
+    _VOLUMES = ['livery', 'liberty', 'library']
+
+    def setUp(self):
+        """
+        Start the stratisd daemon with the simulator.
+        """
+        self._service = Service()
+        self._service.setUp()
+        command_line = ['pool', 'create', self._POOLNAME] \
+            + _DEVICE_STRATEGY.example()
+        RUNNER(command_line)
+
+        command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLUMES[0]
+        RUNNER(command_line)
+        command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLUMES[1]
+        RUNNER(command_line)
+        command_line = ['filesystem', 'create', self._POOLNAME] + self._VOLUMES[2]
+        RUNNER(command_line)
+
+    def tearDown(self):
+        """
+        Stop the stratisd simulator and daemon.
+        """
+        self._service.tearDown()
+
+    def testList(self):
+        """
+        Listing multiple volumes in a non-empty pool should succeed.
+        """
+        command_line = self._MENU + [self._POOLNAME]
+        RUNNER(command_line)
+
+        # Also should work when no pool name is given
+        command_line = ['--propagate', 'filesystem']
+        RUNNER(command_line)
+
+        # Also should work using 'fs' alias
+        command_line = ['--propagate', 'fs']
+        RUNNER(command_line)

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -143,11 +143,17 @@ class List4TestCase(unittest.TestCase):
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
-        command_line = ['filesystem', 'create', self._POOLNAME, self._VOLUMES[0]]
+        command_line = [
+            'filesystem', 'create', self._POOLNAME, self._VOLUMES[0]
+        ]
         RUNNER(command_line)
-        command_line = ['filesystem', 'create', self._POOLNAME, self._VOLUMES[1]]
+        command_line = [
+            'filesystem', 'create', self._POOLNAME, self._VOLUMES[1]
+        ]
         RUNNER(command_line)
-        command_line = ['filesystem', 'create', self._POOLNAME, self._VOLUMES[2]]
+        command_line = [
+            'filesystem', 'create', self._POOLNAME, self._VOLUMES[2]
+        ]
         RUNNER(command_line)
 
     def tearDown(self):

--- a/tests/integration/logical/test_list.py
+++ b/tests/integration/logical/test_list.py
@@ -143,14 +143,11 @@ class List4TestCase(unittest.TestCase):
             + _DEVICE_STRATEGY.example()
         RUNNER(command_line)
 
-        command_line = ['filesystem', 'create', self._POOLNAME
-                        ] + self._VOLUMES[0]
+        command_line = ['filesystem', 'create', self._POOLNAME, self._VOLUMES[0]]
         RUNNER(command_line)
-        command_line = ['filesystem', 'create', self._POOLNAME
-                        ] + self._VOLUMES[1]
+        command_line = ['filesystem', 'create', self._POOLNAME, self._VOLUMES[1]]
         RUNNER(command_line)
-        command_line = ['filesystem', 'create', self._POOLNAME
-                        ] + self._VOLUMES[2]
+        command_line = ['filesystem', 'create', self._POOLNAME, self._VOLUMES[2]]
         RUNNER(command_line)
 
     def tearDown(self):


### PR DESCRIPTION
* Based on example of previous work on blockdevs, do not require pool name to be given.
* Add output of newly added fields: Created date, used space, and mount points.
* Also print Devnode, which is now `/dev/stratis/<poolname>/<fsname>`.

Requires additional dependency on python-dateutil.