### PR TITLE
Augment an error diagnosis

### DIFF
--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -98,10 +98,13 @@ def interpret_errors(errors):
             error.get_dbus_name() == \
             'org.freedesktop.DBus.Error.AccessDenied':
             return "Most likely stratis has insufficient permissions for the action requested."
+        # We have observed two causes of this problem. The first is that
+        # stratisd is not running at all. The second is that stratisd has not
+        # yet established its D-Bus service.
         if isinstance(error, dbus.exceptions.DBusException) and \
             error.get_dbus_name() == \
             'org.freedesktop.DBus.Error.NameHasNoOwner':
-            return "Most likely the Stratis daemon, stratisd, is not running."
+            return "Most likely stratis is unable to connect to the stratisd D-Bus service."
 
         return None
     # pylint: disable=broad-except


### PR DESCRIPTION
As we have seen, we do not have, at this time, any way to disambiguate
between stratisd not running at all and stratisd running but no D-Bus
connection established.

It would be possible to do better, by actually checking.

Signed-off-by: mulhern <amulhern@redhat.com>