### PR TITLE
Remove 'force' option

### DIFF
--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -31,7 +31,7 @@ GLOBAL OPTIONS
 
 COMMANDS
 --------
-pool create [--force] <pool_name> <blockdev> [<blockdev>..]::
+pool create <pool_name> <blockdev> [<blockdev>..]::
      Create a pool from one or more block devices, with the given pool name.
 pool list::
      List all pools on the system.
@@ -39,10 +39,10 @@ pool rename <old_pool_name> <new_pool_name>::
      Rename a pool.
 pool destroy <pool_name>::
      Destroy a pool and all the filesystems created from it.
-pool add-data [--force] <pool_name> <blockdev> [<blockdev>..]::
+pool add-data <pool_name> <blockdev> [<blockdev>..]::
 	 Add one or more blockdevs to an existing pool, to enlarge its storage
 	 capacity.
-pool add-cache [--force] <pool_name> <blockdev> [<blockdev>..]::
+pool add-cache <pool_name> <blockdev> [<blockdev>..]::
 	 Add one or more blockdevs to an existing pool, to be used as a cache
 	 instead of additional storage. Typically, smaller and faster drives,
 	 such as SSDs, are used for this purpose.

--- a/shell-completion/zsh/_stratis
+++ b/shell-completion/zsh/_stratis
@@ -35,7 +35,6 @@ if [[ -n $state ]]; then
   case ${(j.:.)line[1,2]} in
     pool:create)
       _arguments $help \
-	'--force[overwrite existing metadata on specified devices]' \
 	'--redundancy=[specify redundancy level for this pool]:redundancy:(none)' \
 	':pool name' '*:block device:_files -P/ -W/ -g "*(-%)"'
     ;;
@@ -70,7 +69,6 @@ if [[ -n $state ]]; then
     ;;
     blockdev:add-(cache|data))
       _arguments $help \
-	'(-)--force[use devices even if they appear to contain existing data]' \
 	'(-):pool:_stratis_pools' '*:block device:_files -P/ -W/ -g "*(-%)"'
     ;;
     blockdev:list) _arguments $help '(-):pool:_stratis_pools' ;;

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -49,7 +49,6 @@ SPECS = {
 <method name="CreatePool">
 <arg name="name" type="s" direction="in"/>
 <arg name="redundancy" type="(bq)" direction="in"/>
-<arg name="force" type="b" direction="in"/>
 <arg name="devices" type="as" direction="in"/>
 <arg name="result" type="(oao)" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
@@ -70,14 +69,12 @@ SPECS = {
     """
 <interface name="org.storage.stratis1.pool">
 <method name="AddCacheDevs">
-<arg name="force" type="b" direction="in"/>
 <arg name="devices" type="as" direction="in"/>
 <arg name="results" type="ao" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
 <method name="AddDataDevs">
-<arg name="force" type="b" direction="in"/>
 <arg name="devices" type="as" direction="in"/>
 <arg name="results" type="ao" direction="out"/>
 <arg name="return_code" type="q" direction="out"/>

--- a/src/stratis_cli/_actions/_top.py
+++ b/src/stratis_cli/_actions/_top.py
@@ -53,7 +53,6 @@ class TopActions():
             proxy, {
                 'name': namespace.pool_name,
                 'redundancy': (True, 0),
-                'force': namespace.force,
                 'devices': namespace.blockdevs
             })
 
@@ -133,10 +132,7 @@ class TopActions():
             }).search(managed_objects))
 
         (_, rc, message) = Pool.Methods.AddDataDevs(
-            get_object(pool_object_path), {
-                'force': namespace.force,
-                'devices': namespace.device
-            })
+            get_object(pool_object_path), {'devices': namespace.device})
         if rc != StratisdErrors.OK:
             raise StratisCliEngineError(rc, message)
 
@@ -153,9 +149,6 @@ class TopActions():
             }).search(managed_objects))
 
         (_, rc, message) = Pool.Methods.AddCacheDevs(
-            get_object(pool_object_path), {
-                'force': namespace.force,
-                'devices': namespace.device
-            })
+            get_object(pool_object_path), {'devices': namespace.device})
         if rc != StratisdErrors.OK:
             raise StratisCliEngineError(rc, message)

--- a/src/stratis_cli/_parser/_pool.py
+++ b/src/stratis_cli/_parser/_pool.py
@@ -31,12 +31,6 @@ POOL_SUBCMDS = [
                   help='Create the pool using these block devs',
                   nargs='+',
               )),
-             ('--force',
-              dict(
-                  action='store_true',
-                  default=False,
-                  help="Overwrite existing metadata on specified devices",
-              )),
              ('--redundancy',
               dict(
                   action='store',
@@ -93,12 +87,6 @@ POOL_SUBCMDS = [
                   help='Block devices to add to the pool',
                   metavar='blockdev',
                   nargs='+')),
-             ('--force',
-              dict(
-                  action='store_true',
-                  default=False,
-                  help=
-                  "Use devices even if they appear to contain existing data")),
          ],
          func=TopActions.add_data_device)),
     ('add-cache',
@@ -114,12 +102,6 @@ POOL_SUBCMDS = [
                   help='Block devices to add to the pool as cache',
                   metavar='blockdev',
                   nargs='+')),
-             ('--force',
-              dict(
-                  action='store_true',
-                  default=False,
-                  help=
-                  "Use devices even if they appear to contain existing data")),
          ],
          func=TopActions.add_cache_device)),
 ]


### PR DESCRIPTION
We have removed the 'force' parameter in the API call.  The API
caller is now responsible for clearing any signatures before calling
the Stratis dbus API which consumes a block device.

Signed-off-by: Tony Asleson <tasleson@redhat.com>

Fixes https://github.com/stratis-storage/stratisd/issues/613