### PR TITLE
Ignore .pytest_cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache
 
 # Translations
 *.mo


### PR DESCRIPTION
Because it does not belong in source control

Signed-off-by: mulhern <amulhern@redhat.com>