### PR TITLE
Move an unused constant

### DIFF
--- a/src/stratis_cli/_actions/_constants.py
+++ b/src/stratis_cli/_actions/_constants.py
@@ -17,7 +17,6 @@ General constants.
 
 SERVICE = 'org.storage.stratis1'
 TOP_OBJECT = '/org/storage/stratis1'
-MANAGER_INTERFACE = 'org.storage.stratis1.Manager'
 
 SECTOR_SIZE = 512
 

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -197,6 +197,8 @@ SPECS = {
 """,
 }
 
+_MANAGER_INTERFACE = 'org.storage.stratis1.Manager'
+
 _FILESYSTEM_INTERFACE = 'org.storage.stratis1.filesystem'
 _POOL_INTERFACE = 'org.storage.stratis1.pool'
 _BLOCKDEV_INTERFACE = 'org.storage.stratis1.blockdev'
@@ -239,8 +241,7 @@ try:
     MODev = managed_object_class("MODev", blockdev_spec)
     devs = mo_query_builder(blockdev_spec)
 
-    Manager = make_class("Manager",
-                         ET.fromstring(SPECS['org.storage.stratis1.Manager']),
+    Manager = make_class("Manager", ET.fromstring(SPECS[_MANAGER_INTERFACE]),
                          DBUS_TIMEOUT_SECONDS)
 
     ObjectManager = make_class(


### PR DESCRIPTION
Remove MANAGER_INTERFACE from _constants.py, as it is unused. Rename it to
_MANAGER_INTERFACE and define it in _data.py, where it can be used.

Signed-off-by: mulhern <amulhern@redhat.com>