### PR TITLE
Adjust stratisd version check to allow snapshot releases

### DIFF
--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -29,7 +29,7 @@ from .._errors import StratisCliValueError
 
 from ._constants import DBUS_TIMEOUT_SECONDS
 
-MAXIMUM_STRATISD_VERSION = (1, 0, 2)
+MAXIMUM_STRATISD_VERSION = (1, 0, 99)
 MINIMUM_STRATISD_VERSION = (1, 0, 0)
 
 # a sanity check on the relation between the minimum and maximum versions


### PR DESCRIPTION
If we call the version parts x.y.z, let's allow the cli to work with all
1.0.z releases, since we don't want to have to update this value every
time we do a snapshot (where z is incremented). I just tagged a 1.0.3,
in fact, which we want to not trigger the version check.

The consequence is that when we *do* land any API changes in stratisd, we
will need bump the y version. (Maybe at some point we should break API
version out from stratisd's version, but for now they are linked.)

Signed-off-by: Andy Grover <agrover@redhat.com>