### PR TITLE
Correct column alignment for unicode characters (final)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,8 @@ setuptools.setup(
         'Topic :: System :: Filesystems', 'Topic :: Systems Administration'
     ],
     install_requires=[
-        'dbus-client-gen>=0.4',
-        'dbus-python-client-gen>=0.5',
-        'justbytes==0.11',
-        'python-dateutil',
+        'dbus-client-gen>=0.4', 'dbus-python-client-gen>=0.5',
+        'justbytes==0.11', 'python-dateutil', 'wcwidth'
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -35,7 +35,7 @@ def _get_column_width_chars(column_width_cells, entry):
 
     :returns: the column width in characters
 
-    Precondition: mcswidth(entry) != -1
+    Precondition: wcswidth(entry) != -1
                   (equivalently, entry has no unprintable characters)
     """
     return column_width_cells - (wcswidth(entry) - len(entry))
@@ -50,9 +50,10 @@ def _print_row(file, num_columns, row, column_widths, column_alignments):
     :param int num_columns: the number of columns in the table
     :param list row: the list of items to print
     :param list column_widths: corresponding list of column widths
-    :param list column_alignments: correspoindg list of column alignment specs
+    :param list column_alignments: corresponding list of column alignment specs
 
-    Precondition: num_columns == len(row) == len(column_widths) == len(aligment)
+    Precondition: num_columns == len(row) == len(column_widths) ==
+                  len(alignment)
     Precondition: no elements of row have unprintable characters
     """
     for index in range(num_columns):
@@ -79,8 +80,8 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
     Precondition: len(column_headings) == len(alignment) == len of each entry
     in row_entries.
 
-    Precondition: all(mcswidth(h) != -1 for h in column_headings)
-                  all(mcswidth(i) != -1 for row in rows for item in row)
+    Precondition: all(wcswidth(h) != -1 for h in column_headings)
+                  all(wcswidth(i) != -1 for row in rows for item in row)
                   (in other words, no items to be printed contain
                    unprintable characters)
     """

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -100,3 +100,41 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
     for row in row_entries:
         _print_row(file, num_columns, row, column_lengths, alignment)
         print(file=file)
+
+
+def main():
+    """
+    A function that prints out some tables.
+    To be used for a visual check of correctness of formatting.
+    """
+
+    print("Example table...")
+    table = [['Pool Name', 'Name', 'Used', 'Created', 'Device'], [
+        'yes_you_can', '☺', '546 MiB', 'Oct 05 2018 16:24',
+        '/dev/stratis/yes_you_can/☺'
+    ], [
+        'yes_you_can', '漢字', '546 MiB', 'Oct 10 2018 09:37',
+        '/dev/stratis/yes_you_can/漢字'
+    ]]
+    print_table(table[0], table[1:], ['<', '<', '<', '<', '<'])
+
+    print()
+    print("Example table...")
+    table = [['Pool Name', 'Name', 'Used', 'Created', 'Device', 'UUID'], [
+        'unicode', 'e', '546 MiB', 'Feb 07 2019 15:33', '/stratis/unicode/e',
+        '3bf22806a6df4660aa527d646209595f'
+    ], [
+        'unicode', 'eeee', '546 MiB', 'Feb 07 2019 15:33',
+        '/stratis/unicode/eeee', '17101e39e72e423c90d8be5cb37c055b'
+    ], [
+        'unicodé', 'é', '546 MiB', 'Feb 07 2019 15:33',
+        '/stratis/unicodé/é', '0c2caf641dde41beb40bed6911f75c74'
+    ], [
+        'unicodé', 'éééé', '546 MiB', 'Feb 07 2019 15:33',
+        '/stratis/unicodé/éééé', '4ecacb15fb64453191d7da731c5f1601'
+    ]]
+    print_table(table[0], table[1:], ['<', '<', '<', '<', '<', '<'])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -76,6 +76,8 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
     :type row_entries: list of list of str
     :param alignment: the alignment indicator for each key, '<', '>', '^', '='
     :type alignment: list of str
+    :param file: file to print too
+    :type file: writeable stream
 
     Precondition: len(column_headings) == len(alignment) == len of each entry
     in row_entries.

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -41,6 +41,29 @@ def _get_column_width_chars(column_width_cells, entry):
     return column_width_cells - (wcswidth(entry) - len(entry))
 
 
+def _print_row(file, num_columns, row, column_widths, column_alignments):
+    """
+    Print a single row in a table. The row might be the header row, or
+    a row of data items.
+
+    :param file: file to print to
+    :param int num_columns: the number of columns in the table
+    :param list row: the list of items to print
+    :param list column_widths: corresponding list of column widths
+    :param list column_alignments: correspoindg list of column alignment specs
+
+    Precondition: num_columns == len(row) == len(column_widths) == len(aligment)
+    Precondition: no elements of row have unprintable characters
+    """
+    for index in range(num_columns):
+        entry = row[index]
+        column_width_chars = _get_column_width_chars(column_widths[index],
+                                                     entry)
+        line = '{0:{align}{width}}'.format(
+            entry, align=column_alignments[index], width=column_width_chars)
+        print(line, end='', file=file)
+
+
 def print_table(column_headings, row_entries, alignment, file=sys.stdout):
     """
     Given the column headings and the row_entries, print a table.
@@ -71,22 +94,9 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
         for index in range(num_columns)
     ]
 
-    for index in range(num_columns):
-        entry = column_headings[index]
-        column_width_chars = _get_column_width_chars(column_lengths[index],
-                                                     entry)
-        line = '{0:{align}{width}}'.format(
-            entry, align=alignment[index], width=column_width_chars)
-        print(line, end='', file=file)
+    _print_row(file, num_columns, column_headings, column_lengths, alignment)
     print(file=file)
 
     for row in row_entries:
-        for index in range(num_columns):
-            entry = row[index]
-            column_width_chars = _get_column_width_chars(
-                column_lengths[index], entry)
-
-            line = '{0:{align}{width}}'.format(
-                entry, align=alignment[index], width=column_width_chars)
-            print(line, end='', file=file)
+        _print_row(file, num_columns, row, column_lengths, alignment)
         print(file=file)

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -41,13 +41,12 @@ def _get_column_width_chars(column_width_cells, entry):
     return column_width_cells - (wcswidth(entry) - len(entry))
 
 
-def _print_row(file, num_columns, row, column_widths, column_alignments):
+def _print_row(file, row, column_widths, column_alignments):
     """
     Print a single row in a table. The row might be the header row, or
     a row of data items.
 
     :param file: file to print to
-    :param int num_columns: the number of columns in the table
     :param list row: the list of items to print
     :param list column_widths: corresponding list of column widths
     :param list column_alignments: corresponding list of column alignment specs
@@ -56,8 +55,7 @@ def _print_row(file, num_columns, row, column_widths, column_alignments):
                   len(alignment)
     Precondition: no elements of row have unprintable characters
     """
-    for index in range(num_columns):
-        entry = row[index]
+    for index, entry in enumerate(row):
         column_width_chars = _get_column_width_chars(column_widths[index],
                                                      entry)
         line = '{0:{align}{width}}'.format(
@@ -97,11 +95,11 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
         for index in range(num_columns)
     ]
 
-    _print_row(file, num_columns, column_headings, column_lengths, alignment)
+    _print_row(file, column_headings, column_lengths, alignment)
     print(file=file)
 
     for row in row_entries:
-        _print_row(file, num_columns, row, column_lengths, alignment)
+        _print_row(file, row, column_lengths, alignment)
         print(file=file)
 
 

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -34,6 +34,11 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
 
     Precondition: len(column_headings) == len(alignment) == len of each entry
     in row_entries.
+
+    Precondition: all(mcswidth(h) != -1 for h in column_headings)
+                  all(mcswidth(i) != -1 for row in rows for item in row)
+                  (in other words, no items to be printed contain
+                   unprintable characters)
     """
 
     num_columns = len(column_headings)
@@ -58,10 +63,8 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
             column_width = column_lengths[index]
             entry = row[index]
 
-            # -1 is returned for non-printable wide character
             entry_width = wcswidth(entry)
-            if entry_width != -1:
-                column_width -= entry_width - len(entry)
+            column_width -= entry_width - len(entry)
 
             line = '{0:{align}{width}}'.format(
                 entry, align=alignment[index], width=column_width)

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -17,10 +17,7 @@ Formatting for tables.
 
 import sys
 
-try:
-    from wcwidth import wcswidth as maybe_wcswidth
-except ImportError:
-    maybe_wcswidth = len
+from wcwidth import wcswidth
 
 
 def print_table(column_headings, row_entries, alignment, file=sys.stdout):
@@ -43,8 +40,8 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
 
     column_lengths = [
         max(
-            max((maybe_wcswidth(e[index]) for e in row_entries), default=0),
-            maybe_wcswidth(column_headings[index])) + 2
+            max((wcswidth(e[index]) for e in row_entries), default=0),
+            wcswidth(column_headings[index])) + 2
         for index in range(num_columns)
     ]
 
@@ -62,7 +59,7 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
             entry = row[index]
 
             # -1 is returned for non-printable wide character
-            entry_width = maybe_wcswidth(entry)
+            entry_width = wcswidth(entry)
             if entry_width != -1:
                 column_width -= entry_width - len(entry)
 

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -20,6 +20,27 @@ import sys
 from wcwidth import wcswidth
 
 
+def _get_column_width_chars(column_width_cells, entry):
+    """
+    From the desired column width in cells and the item to be printed,
+    calculate the required column width in characters to pass to the
+    format method.
+
+    In order to get the correct width in chars it is necessary to subtract
+    the number of cells above 1 (or add the number of cells below 1) that
+    an individual character occupies.
+
+    :param int column_width_cells: the column width, in cells
+    :param str entry: the entry to be printed
+
+    :returns: the column width in characters
+
+    Precondition: mcswidth(entry) != -1
+                  (equivalently, entry has no unprintable characters)
+    """
+    return column_width_cells - (wcswidth(entry) - len(entry))
+
+
 def print_table(column_headings, row_entries, alignment, file=sys.stdout):
     """
     Given the column headings and the row_entries, print a table.
@@ -51,22 +72,21 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
     ]
 
     for index in range(num_columns):
+        entry = column_headings[index]
+        column_width_chars = _get_column_width_chars(column_lengths[index],
+                                                     entry)
         line = '{0:{align}{width}}'.format(
-            column_headings[index],
-            align=alignment[index],
-            width=column_lengths[index])
+            entry, align=alignment[index], width=column_width_chars)
         print(line, end='', file=file)
     print(file=file)
 
     for row in row_entries:
         for index in range(num_columns):
-            column_width = column_lengths[index]
             entry = row[index]
-
-            entry_width = wcswidth(entry)
-            column_width -= entry_width - len(entry)
+            column_width_chars = _get_column_width_chars(
+                column_lengths[index], entry)
 
             line = '{0:{align}{width}}'.format(
-                entry, align=alignment[index], width=column_width)
+                entry, align=alignment[index], width=column_width_chars)
             print(line, end='', file=file)
         print(file=file)


### PR DESCRIPTION
When we calculate the column widths we need to use how many columns
the text will occupy, not the number of characters.  When we output
the text for each piece of the column we need to adjust the width
to compenstate for this as well.

Corrects: https://github.com/stratis-storage/stratis-cli/issues/205

Signed-off-by: Tony Asleson <tasleson@redhat.com>
Signed-off-by: mulhern <amulhern@redhat.com>