### PR TITLE
Add path to .cargo/bin to include the "cargo" command

### DIFF
--- a/tests/ci/cli.sh
+++ b/tests/ci/cli.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export PATH="$HOME/.cargo/bin:$PATH"
+
 # Jenkins will set WORKSPACE to the top level directory that contains
 # the stratis-cli git repo
 if [ -z "$WORKSPACE" ]


### PR DESCRIPTION
Jenkins uses the fedora-user ID to connect to cloud nodes.  The script is
invoked via "sudo -E ./tests/ci/cli.sh" because it requires root
permissions.  The root shell by default does not have a path to cargo set.

Signed-off-by: Todd Gill <tgill@redhat.com>