### PR TITLE
Change display on error

### DIFF
--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -122,9 +122,8 @@ def handle_error(err):
     if explanation is None:
         exit_msg = (
             "stratis encountered an unexpected error during execution. "
-            "Please report the error at "
-            "https://github.com/stratis-storage/stratis-cli, and "
-            "include the stack trace below.")
+            "Please report the error and include in your report the stack "
+            "trace shown below.")
         print(exit_msg, os.linesep, file=sys.stderr, flush=True)
         raise err
 

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -19,11 +19,9 @@ import sys
 
 import dbus
 
-from dbus_client_gen import DbusClientMissingInterfaceError
 from dbus_client_gen import DbusClientMissingPropertyError
 from dbus_client_gen import DbusClientMissingSearchPropertiesError
 from dbus_client_gen import DbusClientUniqueResultError
-from dbus_client_gen import DbusClientUnknownSearchPropertiesError
 
 from ._actions import interface_name_to_common_name
 from ._errors import StratisCliEngineError
@@ -33,9 +31,6 @@ _DBUS_INTERFACE_MSG = (
     "D-Bus interface than the one stratisd provides. Most likely "
     "you are running a version that requires a newer version of "
     "stratisd than you are running.")
-
-_STRATIS_CLI_BUG_MSG = ("Most likely there is a bug in stratis, the program "
-                        "you are running.")
 
 
 def get_errors(exc):
@@ -81,12 +76,8 @@ def interpret_errors(errors):
             return fmt_str % interface_name_to_common_name(
                 error.interface_name)
 
-        if isinstance(error, DbusClientUnknownSearchPropertiesError):
-            return _STRATIS_CLI_BUG_MSG
         if isinstance(error, DbusClientMissingSearchPropertiesError):
             return _DBUS_INTERFACE_MSG
-        if isinstance(error, DbusClientMissingInterfaceError):
-            return _STRATIS_CLI_BUG_MSG
         if isinstance(error, DbusClientMissingPropertyError):
             return _DBUS_INTERFACE_MSG
 

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -62,13 +62,6 @@ def interpret_errors(errors):
     try:
         # Inspect top-most error after StratisCliActionError
         error = errors[1]
-        if isinstance(error, AttributeError):
-            import traceback
-            frame = traceback.extract_tb(error.__traceback__)[-1]
-            fmt_str = (
-                "Most likely there is an error in the source at line %d "
-                "in file %s. The text of the line is \"%s\".")
-            return fmt_str % (frame.lineno, frame.filename, frame.line)
 
         if isinstance(error,
                       DbusClientUniqueResultError) and error.result == []:

--- a/src/stratis_cli/_main.py
+++ b/src/stratis_cli/_main.py
@@ -46,7 +46,8 @@ def run():
         try:
             try:
                 result.func(result)
-            except (dbus.exceptions.DBusException, AttributeError,
+            except (ArithmeticError, AttributeError, NameError, SyntaxError,
+                    TypeError, dbus.exceptions.DBusException,
                     DbusClientRuntimeError, DPClientRuntimeError,
                     StratisCliRuntimeError) as err:
                 raise StratisCliActionError(command_line_args, result) from err


### PR DESCRIPTION
Previously, if the action failed and an exception was raised, an abbreviated version of the chained exceptions was displayed to the user. If there was a summary explanation for the problem, indicating the most likely cause, that was displayed at the end.

Now, if there is a summary explanation, only the summary explanation is displayed. If there is no explanation, then it is considered an unexpected error and a completely different action is taken:

1. A message is printed indicating that the error is unexpected and that the user should report the error at the stratis-cli GitHub site.
2. The exception is reraised.

The result of this is that what the user sees is the error message described in (1) followed by a display of the stack trace, including all chained exceptions.

There are only two drawbacks to this approach that I can see:
* It might be that the explanation is wrong. In order to avoid this, the explanations are constructed to say only what is actually certain, but this could still be misleading. Even a carefully phrased explanation might be misinterpreted by a user to be more definite than it actually is. If the explanation is really wrong, then a process is required to find out what the true cause actually is, and no stack trace is really available for diagnosis. However, at least some of the stack trace can be inferred from the code and the explanation, so that would not leave us totally at a loss.
* The simplest and best thing to do, in order to have the stack trace properly printed, is to reraise the exception and allow the Python interpreter to handle displaying it. This means that in this case it is the Python interpreter that chooses the error code for the process, not stratis-cli.

Also, please note that there is one known error for which there is no summary explanation. That is the one where GetManagedObjects() fails because some property cannot be obtained by stratisd. I think that in this case it is better to fix the GetManagedObjects failure on the stratisd side, but if necessary, the exception could be fielded and explained.