### PR TITLE
blackbox: fix units_to_bytes return

### DIFF
--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -49,7 +49,7 @@ def units_to_bytes(size, units):
         "EiB": 1024**6,
         "ZiB": 1024**7
     }
-    return int(size) * conv[units]
+    return float(size) * conv[units]
 
 
 def stratis_link(pool_name, fs_name=None):


### PR DESCRIPTION
The units_to_bytes function is always failing due to the input
variable "size" always containing a period (e.g.: "10.00"); the
call fails with "ValueError: invalid literal for int() with base 10".

To avoid losing precision on the size calculation, change the call
to "float(size)", which should always work when there is a period
in the string.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>