### PR TITLE
blackbox: make units_to_bytes return a string

### DIFF
--- a/tests/blackbox/testlib/stratis.py
+++ b/tests/blackbox/testlib/stratis.py
@@ -18,10 +18,7 @@ import datetime
 import os
 import time
 
-from .utils import (exec_command,
-                    rs,
-                    umount_mdv,
-                    stratis_link,
+from .utils import (exec_command, rs, umount_mdv, stratis_link,
                     size_representation)
 
 # Some packaged systems might place this in /usr/sbin

--- a/tests/blackbox/testlib/stratis.py
+++ b/tests/blackbox/testlib/stratis.py
@@ -18,7 +18,11 @@ import datetime
 import os
 import time
 
-from .utils import exec_command, rs, umount_mdv, stratis_link, units_to_bytes
+from .utils import (exec_command,
+                    rs,
+                    umount_mdv,
+                    stratis_link,
+                    size_representation)
 
 # Some packaged systems might place this in /usr/sbin
 STRATIS_CLI = os.getenv("STRATIS_CLI", "/usr/bin/stratis")
@@ -95,8 +99,8 @@ class StratisCli:
 
             if name.startswith(TEST_PREF):
                 rc[name] = dict(
-                    SIZE=units_to_bytes(size, size_units),
-                    USED=units_to_bytes(used, used_units))
+                    SIZE=size_representation(size, size_units),
+                    USED=size_representation(used, used_units))
         return rc
 
     @staticmethod
@@ -139,7 +143,7 @@ class StratisCli:
 
             rc[name] = dict(
                 POOL_NAME=pool_name,
-                USED_SIZE=units_to_bytes(used, used_units),
+                USED_SIZE=size_representation(used, used_units),
                 UUID=uuid,
                 SYM_LINK=sym_link,
                 CREATED=created,
@@ -172,7 +176,7 @@ class StratisCli:
             if pool_name.startswith(TEST_PREF):
                 rc[device_node] = dict(
                     POOL_NAME=pool_name,
-                    SIZE=units_to_bytes(size, size_units),
+                    SIZE=size_representation(size, size_units),
                     STATE=state,
                     TIER=tier)
 

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -33,7 +33,7 @@ def rs(length=4):
         random.choice(string.ascii_uppercase) for _ in range(length)))
 
 
-def units_to_bytes(size, units):
+def size_representation(size, units):
     """
     Convert size and units to a string
     :param size: Size to convert (numeric as a string from CLI output)

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -35,21 +35,12 @@ def rs(length=4):
 
 def units_to_bytes(size, units):
     """
-    Convert size and units to bytes
+    Convert size and units to a string
     :param size: Size to convert (numeric as a string from CLI output)
     :param units: Unit designator
-    :return: Number of bytes
+    :return: String with size and units
     """
-    conv = {
-        "KiB": 1024**1,
-        "MiB": 1024**2,
-        "GiB": 1024**3,
-        "TiB": 1024**4,
-        "PiB": 1024**5,
-        "EiB": 1024**6,
-        "ZiB": 1024**7
-    }
-    return int(size) * conv[units]
+    return size + units
 
 
 def stratis_link(pool_name, fs_name=None):


### PR DESCRIPTION
The units_to_bytes function is always failing due to the input
variable "size" always containing a period (e.g.: "10.00"); the
call fails with "ValueError: invalid literal for int() with base 10".

However, all of the callers of units_to_bytes() only use the return
value as a string in a dictionary, therefore returning the value
as a concatenation of size + units allows the tests to pass.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>