### PR TITLE
blackbox: re-enable signal_interruption test

### DIFF
--- a/tests/blackbox/stratis_cert.py
+++ b/tests/blackbox/stratis_cert.py
@@ -233,7 +233,6 @@ class StratisCertify(unittest.TestCase):
         self.assertFalse(fs_name in fs.keys())
         self.assertEqual(1, len(fs))
 
-    @unittest.expectedFailure
     def test_signal_interruption(self):
         """
         Send a signal in the middle of a command to ensure that we don't get


### PR DESCRIPTION
The test_signal_interruption test should succeed now, therefore
remove the "@unittest.expectedFailure" tag above its definition.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>