### PR TITLE
blackbox: update README stratis_cert.py example block devices

### DIFF
--- a/tests/blackbox/README.md
+++ b/tests/blackbox/README.md
@@ -11,7 +11,7 @@ Run the test as root and supply 3 or more block devices on the
 command line that are blank for test use, eg.
 
 ```bash
-# python3 stratis_cert.py -v --disk /dev/vda --disk /dev/vdb --disk /dev/vdc
+# python3 stratis_cert.py -v --disk /dev/vdb --disk /dev/vdc --disk /dev/vdd
 ```
 
 Notes


### PR DESCRIPTION
The example execution of the stratis_cert.py test shows the block
devices "/dev/vda", "/dev/vdb", and "/dev/vdc" as the test devices.
However, there's a good chance that the test system has its operating
system installed on "/dev/vda", so change the test devices to
"/dev/vdb", "/dev/vdc", and "dev/vdd".

Signed-off-by: Bryan Gurney <bgurney@redhat.com>