### PR TITLE
Do not make assertions about elapsed time in fs_list

### DIFF
--- a/tests/blackbox/testlib/stratis.py
+++ b/tests/blackbox/testlib/stratis.py
@@ -131,12 +131,6 @@ class StratisCli:
             ts = time.mktime(
                 datetime.datetime.strptime(created,
                                            "%b %d %Y %H:%M").timetuple())
-            now = time.time()
-
-            # Everything we have created should have occurred very recently, but
-            # our CI systems can be slow, so give them some time, we might need
-            # to remove this assert if it becomes problematic.
-            assert (now - ts) < 300.0
 
             rc[name] = dict(
                 POOL_NAME=pool_name,


### PR DESCRIPTION
* It's not part of the specification of the function.
* How long execution of tests can take is machine dependent, so upper
bounds on elapsed time should not be hard-coded in the test.

Signed-off-by: mulhern <amulhern@redhat.com>