### PR TITLE
Increase version requirement for dbus-python-client-gen to 0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         'Topic :: System :: Filesystems', 'Topic :: Systems Administration'
     ],
     install_requires=[
-        'dbus-client-gen>=0.4', 'dbus-python-client-gen>=0.5',
+        'dbus-client-gen>=0.4', 'dbus-python-client-gen>=0.6',
         'justbytes==0.11', 'python-dateutil', 'wcwidth'
     ],
     package_dir={"": "src"},


### PR DESCRIPTION
stratis-cli can not be run w/ an earlier version. Note that a 0.7 version of
dbus-python-client-gen does exist, but stratis-cli does not at this time
require it. Version 0.7 extended the error-heirarchy, exported some
new error types in the public interface, and improved a number of error
messages. It adds value, as the error messages are much better on certain
dbus-python method failures in 0.7 than in 0.6. But there is no dependency
and never has been.

The dependency on 0.6 was introduced in commit
82929a0ec475f7d15b5cc30d120c2c1b200.

Signed-off-by: mulhern <amulhern@redhat.com>