### PR TITLE
Get rid of blackbox tests that require the rpm Python package

### DIFF
--- a/tests/blackbox/README.md
+++ b/tests/blackbox/README.md
@@ -1,43 +1,11 @@
-
 The intention for the test in this directory are for verifying that a
 released, packaged, and installed instance of Stratis is functional.
 Thus the test assumes that the `stratisd` daemon and the `stratis` command
 line are installed, although the test will start the daemon if needed.
-Initially this test is only expected to run for fedora packaging tests, but
-we could run with Travis CI or Jenkins tests as well if
-we elected to build installable packages during the CI process too.
 
 Run the test as root and supply 3 or more block devices on the
 command line that are blank for test use, eg.
 
 ```bash
 # python3 stratis_cert.py -v --disk /dev/vdb --disk /dev/vdc --disk /dev/vdd
-```
-
-Notes
-* Some tests are expecting to fail at this time.  When the issues are corrected
-the test will be updated to change its expectation.
-* The test is written with the expectation that it's running on an rpm based
-distribution.  To make this work on different installed distributions we need
-to modify `./tests/blackbox/testlib/utils.py` function `rpm_package_version` to
-work on all, to retrieve the packaged version installed.
-
-```python
-import rpm
-
-
-def rpm_package_version(name):
-    """
-    Retrieve the version of the specified package
-    :param name: Name of package
-    :return: String representation of version, None if package not found.
-    """
-    ts = rpm.TransactionSet()
-    mi = ts.dbMatch('name', name)
-
-    for i in mi:
-        return i["version"].decode("utf-8")
-
-    return None
-
 ```

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -22,8 +22,8 @@ import time
 import unittest
 from subprocess import Popen, PIPE
 
-from testlib.utils import exec_command, rpm_package_version, process_exists, \
-    file_create, file_signature, rs, stratis_link
+from testlib.utils import (exec_command, process_exists, file_create,
+                           file_signature, rs, stratis_link)
 from testlib.stratis import StratisCli, STRATIS_CLI, fs_n, p_n
 
 DISKS = []
@@ -60,14 +60,6 @@ class StratisCertify(unittest.TestCase):
         """
         StratisCli.destroy_all()
         self.assertEqual(0, len(StratisCli.pool_list()))
-
-    def test_client_version(self):
-        """
-        Ref. https://bugzilla.redhat.com/show_bug.cgi?id=1652124
-        :return: None
-        """
-        self.assertEqual(
-            rpm_package_version('stratis-cli'), StratisCli.cli_version())
 
     def test_daemon_redundancy(self):
         """

--- a/tests/blackbox/stratisd_cert.py
+++ b/tests/blackbox/stratisd_cert.py
@@ -22,8 +22,8 @@ import time
 import unittest
 from subprocess import Popen, PIPE
 
-from testlib.utils import exec_command, rpm_package_version, process_exists, \
-    file_create, file_signature, rs, stratis_link
+from testlib.utils import (exec_command, process_exists, file_create,
+                           file_signature, rs, stratis_link)
 from testlib.stratis import StratisCli, STRATIS_CLI, fs_n, p_n
 
 DISKS = []
@@ -60,14 +60,6 @@ class StratisCertify(unittest.TestCase):
         """
         StratisCli.destroy_all()
         self.assertEqual(0, len(StratisCli.pool_list()))
-
-    def test_service_version(self):
-        """
-        Ensure package and version reported from CLI match.
-        :return: None
-        """
-        self.assertEqual(
-            rpm_package_version("stratisd"), StratisCli.daemon_version())
 
     def test_pool_create(self):
         """

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -20,8 +20,6 @@ import random
 import string
 from subprocess import Popen, PIPE
 
-import rpm
-
 
 def rs(length=4):
     """
@@ -105,21 +103,6 @@ def exec_command(cmd, expected_exit_code=0):
     assert expected_exit_code == process.returncode
     assert stderr_text == ""
     return stdout_text, stderr_text
-
-
-def rpm_package_version(name):
-    """
-    Retrieve the version of the specified package
-    :param name: Name of package
-    :return: String representation of version, None if package not found.
-    """
-    ts = rpm.TransactionSet()
-    mi = ts.dbMatch('name', name)
-
-    for i in mi:
-        return i["version"].decode("utf-8")
-
-    return None
 
 
 def md5(t):


### PR DESCRIPTION
Resolves: https://github.com/stratis-storage/project/issues/41
Resolves: https://github.com/stratis-storage/project/issues/42