### PR TITLE
Remove a few unnecessary pylint directives

### DIFF
--- a/src/stratis_cli/_actions/_stratis.py
+++ b/src/stratis_cli/_actions/_stratis.py
@@ -28,18 +28,16 @@ class StratisActions():
     """
 
     @staticmethod
-    def list_stratisd_redundancy(namespace):
+    def list_stratisd_redundancy(_namespace):
         """
         List the stratisd redundancy designations.
         """
-        # pylint: disable=unused-argument
         for code in RedundancyCodes:
             print("%s: %d" % (code.name, code.value))
 
     @staticmethod
-    def list_stratisd_version(namespace):
+    def list_stratisd_version(_namespace):
         """
         List the stratisd version.
         """
-        # pylint: disable=unused-argument
         print("%s" % Manager.Properties.Version.Get(get_object(TOP_OBJECT)))

--- a/src/stratis_cli/_main.py
+++ b/src/stratis_cli/_main.py
@@ -46,7 +46,6 @@ def run():
             # handled only there; it is just reraised here.
             except KeyboardInterrupt as err:
                 raise err
-            # pylint: disable=broad-except
             except BaseException as err:
                 raise StratisCliActionError(command_line_args, result) from err
         except StratisCliActionError as err:

--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -28,7 +28,6 @@ from ._logical import LOGICAL_SUBCMDS
 from ._physical import PHYSICAL_SUBCMDS
 from ._pool import POOL_SUBCMDS
 
-# pylint: disable=undefined-variable
 PRINT_HELP = lambda parser: lambda _: parser.print_help()
 
 

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -65,7 +65,6 @@ class _Service():
         """
         Stop the stratisd simulator and daemon.
         """
-        # pylint: disable=no-member
         self._stratisd.terminate()
         self._stratisd.wait()
 


### PR DESCRIPTION
This sweep removes a bunch of unnecessary pylint directives. All remaining directives are required.