### PR TITLE
Make bash completion aware of --propagate

### DIFF
--- a/shell-completion/bash/stratis
+++ b/shell-completion/bash/stratis
@@ -1,15 +1,33 @@
 _stratis()
 {
-	local cur prev x2prev x3prev opts root_subcommands pool_subcommands fs_subcommands blockdev_subcommands daemon_subcommands complete_pools blockdevs first second third
+	local cur prev x2prev x3prev opts root_subcommands pool_subcommands fs_subcommands blockdev_subcommands daemon_subcommands complete_pools blockdevs first second third comp_cword_adj
+
 	COMPREPLY=()
+	comp_words_adj=()
+
+	comp_cword_adj="${COMP_CWORD}"
+
+# Turn comp_cword_adj and comp_word_adj into versions of COMP_WORD
+# and COMP_CWORD that pretend --propagate doesn't exist
+	for word in "${COMP_WORDS[@]}"
+	do
+		if [[ ${word} == "--propagate" ]]; then
+			((comp_cword_adj--))
+		else
+			comp_words_adj+=(${word})
+		fi
+	done
+	
+# The current word needs to be able to be completed for --propagate
 	cur="${COMP_WORDS[COMP_CWORD]}"
-	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	x2prev="${COMP_WORDS[COMP_CWORD-2]}"
-	x3prev="${COMP_WORDS[COMP_CWORD-3]}"
-	first="${COMP_WORDS[1]}"
-	second="${COMP_WORDS[2]}"
-	third="${COMP_WORDS[3]}"
-	opts="-h --help --version"
+# The other words must ignore --propagate and use adjusted values
+	prev="${comp_words_adj[comp_cword_adj-1]}"
+	x2prev="${comp_words_adj[comp_cword_adj-2]}"
+	x3prev="${comp_words_adj[comp_cword_adj-3]}"
+	first="${comp_words_adj[1]}"
+	second="${comp_words_adj[2]}"
+	third="${comp_words_adj[3]}"
+	opts="-h --help --version --propagate"
 	root_subcommands="--help --version daemon pool blockdev filesystem"
 	pool_subcommands="create list add-data add-cache rename destroy"
 	fs_subcommands="create snapshot list rename destroy"
@@ -110,7 +128,7 @@ _stratis()
 		esac
 
 #	Code to handle multiple block device names or multiple filesystem names for filesystem destroy and pool create/add-data/add-cache
-		if [[ ${COMP_CWORD} > 3 ]]; then
+		if [[ ${comp_cword_adj} > 3 ]]; then
 			case ${first} in
 				filesystem|fs)
 					case ${second} in
@@ -136,7 +154,7 @@ _stratis()
 					;;
 			esac
 		fi
-		if [[ ${COMP_CWORD} -eq 1 ]]; then
+		if [[ ${comp_cword_adj} -eq 1 ]]; then
 			COMPREPLY=( $(compgen -W "${root_subcommands}" -- ${cur}) )
 			return 0
 		fi

--- a/shell-completion/bash/stratis
+++ b/shell-completion/bash/stratis
@@ -17,7 +17,7 @@ _stratis()
 			comp_words_adj+=(${word})
 		fi
 	done
-	
+
 # The current word needs to be able to be completed for --propagate
 	cur="${COMP_WORDS[COMP_CWORD]}"
 # The other words must ignore --propagate and use adjusted values
@@ -27,8 +27,9 @@ _stratis()
 	first="${comp_words_adj[1]}"
 	second="${comp_words_adj[2]}"
 	third="${comp_words_adj[3]}"
-	opts="-h --help --version --propagate"
-	root_subcommands="--help --version daemon pool blockdev filesystem"
+	opts="-h --help"
+	global_opts="--version --propagate ${opts}"
+	root_subcommands="daemon pool blockdev filesystem ${global_opts}"
 	pool_subcommands="create list add-data add-cache rename destroy"
 	fs_subcommands="create snapshot list rename destroy"
 	blockdev_subcommands="list"
@@ -36,7 +37,11 @@ _stratis()
 	blockdevs="$(echo /dev/disk/*/*) $(lsblk -n -o name -p -l)"
 
 	if [[ ${cur} == -* ]] ; then
-		COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        if [[ ${comp_cword_adj} -eq 1 ]]; then
+            COMPREPLY=( $(compgen -W "${global_opts}" -- ${cur}) )
+        else
+            COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        fi
 		return 0
 	else
 		case ${prev} in

--- a/shell-completion/bash/stratis
+++ b/shell-completion/bash/stratis
@@ -1,35 +1,19 @@
 _stratis()
 {
-	local cur prev x2prev x3prev opts root_subcommands pool_subcommands fs_subcommands blockdev_subcommands daemon_subcommands complete_pools blockdevs first second third comp_cword_adj
+	local cur prev x2prev x3prev opts root_subcommands pool_subcommands fs_subcommands blockdev_subcommands daemon_subcommands complete_pools blockdevs first second third
 
 	COMPREPLY=()
-	comp_words_adj=()
 
-	comp_cword_adj="${COMP_CWORD}"
-
-# Turn comp_cword_adj and comp_word_adj into versions of COMP_WORD
-# and COMP_CWORD that pretend --propagate doesn't exist
-	for word in "${COMP_WORDS[@]}"
-	do
-		if [[ ${word} == "--propagate" ]]; then
-			((comp_cword_adj--))
-		else
-			comp_words_adj+=(${word})
-		fi
-	done
-
-# The current word needs to be able to be completed for --propagate
 	cur="${COMP_WORDS[COMP_CWORD]}"
-# The other words must ignore --propagate and use adjusted values
-	prev="${comp_words_adj[comp_cword_adj-1]}"
-	x2prev="${comp_words_adj[comp_cword_adj-2]}"
-	x3prev="${comp_words_adj[comp_cword_adj-3]}"
-	first="${comp_words_adj[1]}"
-	second="${comp_words_adj[2]}"
-	third="${comp_words_adj[3]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	x2prev="${COMP_WORDS[COMP_CWORD-2]}"
+	x3prev="${COMP_WORDS[COMP_CWORD-3]}"
+	first="${COMP_WORDS[1]}"
+	second="${COMP_WORDS[2]}"
+	third="${COMP_WORDS[3]}"
 	opts="-h --help"
 	global_opts="--version --propagate ${opts}"
-	root_subcommands="daemon pool blockdev filesystem ${global_opts}"
+	root_subcommands="daemon pool blockdev filesystem"
 	pool_subcommands="create list add-data add-cache rename destroy"
 	fs_subcommands="create snapshot list rename destroy"
 	blockdev_subcommands="list"
@@ -37,7 +21,7 @@ _stratis()
 	blockdevs="$(echo /dev/disk/*/*) $(lsblk -n -o name -p -l)"
 
 	if [[ ${cur} == -* ]] ; then
-        if [[ ${comp_cword_adj} -eq 1 ]]; then
+        if [[ ${COMP_CWORD} -eq 1 ]]; then
             COMPREPLY=( $(compgen -W "${global_opts}" -- ${cur}) )
         else
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
@@ -159,9 +143,12 @@ _stratis()
 					;;
 			esac
 		fi
-		if [[ ${comp_cword_adj} -eq 1 ]]; then
-			COMPREPLY=( $(compgen -W "${root_subcommands}" -- ${cur}) )
+		if [[ ${COMP_CWORD} -eq 1 ]]; then
+			COMPREPLY=( $(compgen -W "${root_subcommands} ${global_opts}" -- ${cur}) )
 			return 0
+		elif [[ ${prev} == "--propagate" ]]; then
+			COMPREPLY=( $(compgen -W "${root_subcommands}" -- ${cur}) )
+			
 		fi
 	fi
 	return 0


### PR DESCRIPTION
The bash completion script was previously unaware of the existence of `--propagate` at all.

With this PR it
* autocompletes the word `--propagate` anywhere in the command;
* ignores the presence of `--propagate` when looking for the previous arguments and counting the number of arguments, so that it doesn't mistake it for the previous argument the user is supposed to provide to the `stratis` command.

Signed-off-by: Carmine Zaccagnino <carmine@carminezacc.com>