### PR TITLE
Add a coverage test for the dbus-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,5 @@ dbus-tests:
 dbus-tests-coverage:
 	python3 -m coverage --version
 	python3 -m coverage run --timid --branch -m pytest ./tests/whitebox
-	python3 -m coverage report -m --fail-under=82 --show-missing --include="./src/*"
+	python3 -m coverage report -m --fail-under=84 --show-missing --include="./src/*"
 	python3 -m coverage html --include="./src/*"

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,9 @@ docs:
 
 dbus-tests:
 	py.test-3 ${PYTEST_OPTS} ./tests/whitebox
+
+dbus-tests-coverage:
+	python3 -m coverage --version
+	python3 -m coverage run --timid --branch -m pytest ./tests/whitebox
+	python3 -m coverage report -m --fail-under=82 --show-missing --include="./src/*"
+	python3 -m coverage html --include="./src/*"

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -125,7 +125,7 @@ def print_table(column_headings, row_entries, alignment, file=sys.stdout):
         print(file=file)
 
 
-def main():
+def main():  # pragma: no cover
     """
     A function that prints out some tables.
     To be used for a visual check of correctness of formatting.
@@ -191,5 +191,5 @@ def main():
     print_table(table[0], table[1:], ["<", "<", "<", "<", "<", "<"])
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
This PR allows us to see the coverage information for the dbus-tests. These tests are the ones that test against the sim engine over the D-Bus.

They are not incorporated into the CI in this PR, we can consider how to incorporate them later.

They are a convenience for developers interested in checking how their changes affect test coverage.

All our Python libraries routinely run coverage and pass with 100% on Travis. The CLI has always been a bit different because we can't run the tests on Travis, and because the tests are not monolithic.

However, it is safe and easy for a developer to run the D-Bus tests on their personal machine, so it's also safe and easy to get coverage information for these tests on their personal machine. Might as well make this coverage information easily accessible.