### PR TITLE
Fix the missing bits in the blackbox tests and enable linting

### DIFF
--- a/check.py
+++ b/check.py
@@ -12,7 +12,14 @@ arg_map = {
         "--disable=invalid-name",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
     ],
-    "tests": [
+    "tests/blackbox": [
+        "--reports=no",
+        "--disable=I",
+        "--disable=duplicate-code",
+        "--disable=invalid-name",
+        "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
+    ],
+    "tests/whitebox": [
         "--reports=no",
         "--disable=I",
         "--disable=duplicate-code",

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -22,8 +22,8 @@ import time
 import unittest
 from subprocess import Popen, PIPE
 
-from testlib.utils import exec_command, process_exists
-from testlib.stratis import StratisCli, STRATIS_CLI, fs_n, p_n
+from .testlib.utils import exec_command, process_exists
+from .testlib.stratis import StratisCli, STRATIS_CLI, fs_n, p_n
 
 DISKS = []
 

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -22,14 +22,7 @@ import time
 import unittest
 from subprocess import Popen, PIPE
 
-from testlib.utils import (
-    exec_command,
-    process_exists,
-    file_create,
-    file_signature,
-    rs,
-    stratis_link,
-)
+from testlib.utils import exec_command, process_exists
 from testlib.stratis import StratisCli, STRATIS_CLI, fs_n, p_n
 
 DISKS = []
@@ -75,7 +68,7 @@ class StratisCertify(unittest.TestCase):
         self.assertEqual(("NONE", 0), StratisCli.daemon_redundancy())
 
     @unittest.expectedFailure
-    def test_no_args(self):
+    def test_no_args(self):  # pylint: disable=no-self-use
         """
         Ref. https://github.com/stratis-storage/stratis-cli/issues/248
         :return: None

--- a/tests/blackbox/stratisd_cert.py
+++ b/tests/blackbox/stratisd_cert.py
@@ -21,7 +21,7 @@ import sys
 import time
 import unittest
 
-from testlib.utils import (
+from .testlib.utils import (
     exec_command,
     process_exists,
     file_create,
@@ -29,7 +29,7 @@ from testlib.utils import (
     rs,
     stratis_link,
 )
-from testlib.stratis import StratisCli, fs_n, p_n
+from .testlib.stratis import StratisCli, fs_n, p_n
 
 DISKS = []
 

--- a/tests/blackbox/stratisd_cert.py
+++ b/tests/blackbox/stratisd_cert.py
@@ -20,7 +20,6 @@ import os
 import sys
 import time
 import unittest
-from subprocess import Popen, PIPE
 
 from testlib.utils import (
     exec_command,
@@ -30,7 +29,7 @@ from testlib.utils import (
     rs,
     stratis_link,
 )
-from testlib.stratis import StratisCli, STRATIS_CLI, fs_n, p_n
+from testlib.stratis import StratisCli, fs_n, p_n
 
 DISKS = []
 

--- a/tests/blackbox/testlib/stratis.py
+++ b/tests/blackbox/testlib/stratis.py
@@ -44,6 +44,10 @@ def fs_n():
 
 
 class StratisCli:
+    """
+    Wrappers around stratis cli command-line calls.
+    """
+
     @staticmethod
     def cli_version():
         """
@@ -80,6 +84,7 @@ class StratisCli:
         :return: A dict,  Key being the pool name, the value being a dict with
                           keys [SIZE, USED]
         """
+        # pylint: disable=too-many-locals
         cmd = [STRATIS_CLI, "pool"]
         if specify_list:
             cmd.append("list")
@@ -109,6 +114,7 @@ class StratisCli:
                           keys [POOL_NAME, USED_SIZE, UUID, SYM_LINK, CREATED,
                                 CREATED_TS]
         """
+        # pylint: disable=too-many-locals
         cmd = [STRATIS_CLI, "fs"]
         if specify_list:
             cmd.append("list")
@@ -250,7 +256,7 @@ class StratisCli:
             StratisCli.fs_destroy(fs["POOL_NAME"], name)
 
         # Remove Pools
-        for name in StratisCli.pool_list().keys():
+        for name in StratisCli.pool_list():
             StratisCli.pool_destroy(name)
 
     @staticmethod

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,5 @@ deps =
 commands =
     ./check.py bin/stratis
     ./check.py src/stratis_cli
-    ./check.py tests
+    ./check.py tests/blackbox
+    ./check.py tests/whitebox


### PR DESCRIPTION
The blackbox tests were missing an initialization file, and so pylint wasn't checking them. Now the blackbox tests have an initialization file and they are getting linted.