### PR TITLE
Extend coverage test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ coverage:
 	python3 -m coverage --version
 	python3 -m coverage run --timid --branch -m pytest ./tests/whitebox/integration
 	python3 -m coverage run --timid --branch -a -m pytest ./tests/whitebox/monkey_patching/test_keyboard_interrupt.py
-	python3 -m coverage report -m --fail-under=85 --show-missing --include="./src/*"
+	python3 -m coverage report -m --fail-under=86 --show-missing --include="./src/*"
 	python3 -m coverage html --include="./src/*"
 
 keyboard-interrupt-test:

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,10 @@ docs:
 dbus-tests:
 	py.test-3 ${PYTEST_OPTS} ./tests/whitebox/integration
 
-dbus-tests-coverage:
+coverage:
 	python3 -m coverage --version
 	python3 -m coverage run --timid --branch -m pytest ./tests/whitebox/integration
+	python3 -m coverage run --timid --branch -a -m pytest ./tests/whitebox/monkey_patching/test_keyboard_interrupt.py
 	python3 -m coverage report -m --fail-under=85 --show-missing --include="./src/*"
 	python3 -m coverage html --include="./src/*"
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ dbus-tests:
 dbus-tests-coverage:
 	python3 -m coverage --version
 	python3 -m coverage run --timid --branch -m pytest ./tests/whitebox/integration
-	python3 -m coverage report -m --fail-under=84 --show-missing --include="./src/*"
+	python3 -m coverage report -m --fail-under=85 --show-missing --include="./src/*"
 	python3 -m coverage html --include="./src/*"
 
 keyboard-interrupt-test:

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -245,11 +245,14 @@ try:
         DBUS_TIMEOUT_SECONDS,
     )
 
-except DPClientGenerationError as err:
+# Do not expect to get coverage on Generation errors.
+# These can only occurs if the XML data in _SPECS is ill-formed; we have
+# complete control over that data and can expect it to be valid.
+except DPClientGenerationError as err:  # pragma: no cover
     raise StratisCliGenerationError(
         "Failed to generate some class needed for invoking dbus-python methods"
     ) from err
-except DbusClientGenerationError as err:
+except DbusClientGenerationError as err:  # pragma: no cover
     raise StratisCliGenerationError(
         "Failed to generate some class needed for examining D-Bus data"
     ) from err

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -26,12 +26,16 @@ import sys
 # available in every distribution due to the non-local nature of its
 # installation mechanism, which builds functions dynamically from tables
 # made available online at www.unicode.org.
+
+# Disable coverage for conditional import. We do not want to make our
+# coverage result dependent on whether wcwidth is available or not, as our
+# tests might be run, and succeed either with or without.
 try:
     from wcwidth import wcswidth
 
-    maybe_wcswidth = wcswidth
+    maybe_wcswidth = wcswidth  # pragma: no cover
 except ImportError:
-    maybe_wcswidth = len
+    maybe_wcswidth = len  # pragma: no cover
 
 
 def _get_column_len(column_width, entry_len, entry_width):

--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -31,13 +31,15 @@ from ._pool import POOL_SUBCMDS
 PRINT_HELP = lambda parser: lambda _: parser.print_help()
 
 
-def add_args(parser, args=None):
+def _add_args(parser, args):
     """
     Call subcommand.add_argument() based on args list.
+
+    :param parser: the parser being build
+    :param list args: a data structure representing the arguments to be added
     """
-    if args is not None:
-        for name, arg in args:
-            parser.add_argument(name, **arg)
+    for name, arg in args:
+        parser.add_argument(name, **arg)
 
 
 def add_subcommand(subparser, cmd):
@@ -55,7 +57,7 @@ def add_subcommand(subparser, cmd):
         for subcmd in subcmds:
             add_subcommand(subparsers, subcmd)
 
-    add_args(parser, info.get("args", []))
+    _add_args(parser, info.get("args", []))
 
     parser.set_defaults(func=info.get("func", PRINT_HELP(parser)))
 
@@ -124,7 +126,7 @@ def gen_parser():
     # version is special, it has explicit support in argparse
     parser.add_argument("--version", action="version", version=__version__)
 
-    add_args(parser, GEN_ARGS)
+    _add_args(parser, GEN_ARGS)
 
     subparsers = parser.add_subparsers(title="subcommands")
 


### PR DESCRIPTION
This extends the coverage test to combine data from the dbus tests and the keyboard interrupt test. It also adds a few well-justified "no cover" pragmas and bumps the required test coverage by two percentage points.

Note that a bunch of the other coverage gaps are fairly interesting, but generally relate to certain stratis commands not being well covered at all, for example filesystem rename. I'm leaving improving or adding to those tests for a subsequent PR.