### PR TITLE
Pay attention to pre-existing stratisd process in SimTestCase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTEST_OPTS = -rsx
+PYTEST_OPTS = --verbose
 
 TOX=tox
 

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -69,6 +69,13 @@ class _Service:
         self._stratisd.terminate()
         self._stratisd.wait()
 
+    def cleanup(self):
+        """
+        Stop the daemon if it has been started.
+        """
+        if hasattr(self, "_stratisd"):
+            self.tearDown()
+
 
 class SimTestCase(unittest.TestCase):
     """
@@ -80,13 +87,8 @@ class SimTestCase(unittest.TestCase):
         Start the stratisd daemon with the simulator.
         """
         self._service = _Service()
+        self.addCleanup(self._service.cleanup)
         self._service.setUp()
-
-    def tearDown(self):
-        """
-        Stop the stratisd simulator and daemon.
-        """
-        self._service.tearDown()
 
 
 RUNNER = run()

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -23,6 +23,8 @@ import sys
 import time
 import unittest
 
+import psutil  # pylint: disable=wrong-import-order
+
 from stratis_cli import run
 
 try:
@@ -81,6 +83,15 @@ class SimTestCase(unittest.TestCase):
     """
     A SimTestCase must always start and stop stratisd (simulator vesion).
     """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Assert that there are no other stratisd processes running.
+        """
+        assert not any(
+            psutil.Process(p).name() == "stratisd" for p in psutil.pids()
+        ), "Evidently a stratisd process is already running."
 
     def setUp(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=lint
 [testenv:lint]
 deps =
     dbus-python
+    psutil
     pylint
     pytest>=2.8
 commands =


### PR DESCRIPTION
Related: https://github.com/stratis-storage/project/issues/54, https://github.com/stratis-storage/project/issues/53, https://github.com/stratis-storage/project/issues/49.

These changes ensure:
1. If a stratisd process has been started by a test, but there is an error in SimTestCase::setUp, the stratisd process will still be terminated by the registered cleanup method.
2. If a stratisd process is already running when the tests are started, there will be an error for each SimTestCase based test indicating that a stratisd process is already running.