### PR TITLE
Postpone loading _data.py module until individual actions are executed

### DIFF
--- a/src/stratis_cli/_actions/__init__.py
+++ b/src/stratis_cli/_actions/__init__.py
@@ -15,7 +15,9 @@
 Package mediating dbus actions.
 """
 
-from ._data import interface_name_to_common_name
+from ._constants import BLOCKDEV_INTERFACE
+from ._constants import FILESYSTEM_INTERFACE
+from ._constants import POOL_INTERFACE
 from ._logical import LogicalActions
 from ._physical import PhysicalActions
 from ._stratis import StratisActions

--- a/src/stratis_cli/_actions/_constants.py
+++ b/src/stratis_cli/_actions/_constants.py
@@ -19,3 +19,7 @@ SERVICE = "org.storage.stratis1"
 TOP_OBJECT = "/org/storage/stratis1"
 
 SECTOR_SIZE = 512
+
+FILESYSTEM_INTERFACE = "org.storage.stratis1.filesystem"
+POOL_INTERFACE = "org.storage.stratis1.pool"
+BLOCKDEV_INTERFACE = "org.storage.stratis1.blockdev"

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -15,6 +15,8 @@
 XML interface specifications.
 """
 
+import sys
+
 import xml.etree.ElementTree as ET
 
 from dbus_client_gen import managed_object_class
@@ -29,6 +31,13 @@ from .._errors import StratisCliGenerationError
 from ._constants import BLOCKDEV_INTERFACE
 from ._constants import FILESYSTEM_INTERFACE
 from ._constants import POOL_INTERFACE
+
+
+assert hasattr(sys.modules.get("stratis_cli"), "run"), (
+    "This module is being loaded too eagerly. Make sure that loading it is "
+    "deferred until after the stratis_cli module has been fully loaded."
+)
+
 
 SPECS = {
     "org.freedesktop.DBus.ObjectManager": """

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -25,7 +25,10 @@ from dbus_python_client_gen import make_class
 from dbus_python_client_gen import DPClientGenerationError
 
 from .._errors import StratisCliGenerationError
-from .._errors import StratisCliValueError
+
+from ._constants import BLOCKDEV_INTERFACE
+from ._constants import FILESYSTEM_INTERFACE
+from ._constants import POOL_INTERFACE
 
 SPECS = {
     "org.freedesktop.DBus.ObjectManager": """
@@ -192,46 +195,21 @@ SPECS = {
 
 _MANAGER_INTERFACE = "org.storage.stratis1.Manager"
 
-_FILESYSTEM_INTERFACE = "org.storage.stratis1.filesystem"
-_POOL_INTERFACE = "org.storage.stratis1.pool"
-_BLOCKDEV_INTERFACE = "org.storage.stratis1.blockdev"
-
 DBUS_TIMEOUT_SECONDS = 120
 
 
-def interface_name_to_common_name(interface_name):
-    """
-    Maps a D-Bus interface name to the common name that identifies the type
-    of stratisd thing that the interface represents.
-
-    :param str interface_name: the interface name
-    :returns: a common name
-    :rtype: str
-    """
-    if interface_name == _BLOCKDEV_INTERFACE:
-        return "block device"
-
-    if interface_name == _FILESYSTEM_INTERFACE:
-        return "filesystem"
-
-    if interface_name == _POOL_INTERFACE:
-        return "pool"
-
-    raise StratisCliValueError(interface_name, "interface_name")
-
-
 try:
-    filesystem_spec = ET.fromstring(SPECS[_FILESYSTEM_INTERFACE])
+    filesystem_spec = ET.fromstring(SPECS[FILESYSTEM_INTERFACE])
     Filesystem = make_class("Filesystem", filesystem_spec, DBUS_TIMEOUT_SECONDS)
     MOFilesystem = managed_object_class("MOFilesystem", filesystem_spec)
     filesystems = mo_query_builder(filesystem_spec)
 
-    pool_spec = ET.fromstring(SPECS[_POOL_INTERFACE])
+    pool_spec = ET.fromstring(SPECS[POOL_INTERFACE])
     Pool = make_class("Pool", pool_spec, DBUS_TIMEOUT_SECONDS)
     MOPool = managed_object_class("MOPool", pool_spec)
     pools = mo_query_builder(pool_spec)
 
-    blockdev_spec = ET.fromstring(SPECS[_BLOCKDEV_INTERFACE])
+    blockdev_spec = ET.fromstring(SPECS[BLOCKDEV_INTERFACE])
     MODev = managed_object_class("MODev", blockdev_spec)
     devs = mo_query_builder(blockdev_spec)
 

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -24,13 +24,6 @@ from .._stratisd_constants import StratisdErrors
 
 from ._connection import get_object
 from ._constants import TOP_OBJECT
-from ._data import MOFilesystem
-from ._data import MOPool
-from ._data import ObjectManager
-from ._data import Pool
-from ._data import Filesystem
-from ._data import filesystems
-from ._data import pools
 from ._formatting import print_table
 
 
@@ -46,6 +39,10 @@ class LogicalActions:
 
         :raises StratisCliEngineError:
         """
+        from ._data import ObjectManager
+        from ._data import Pool
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = next(
@@ -66,6 +63,12 @@ class LogicalActions:
         """
         List the volumes in a pool.
         """
+        from ._data import MOFilesystem
+        from ._data import MOPool
+        from ._data import ObjectManager
+        from ._data import filesystems
+        from ._data import pools
+
         # This method is invoked as the default for "stratis filesystem";
         # the namespace may not have a pool_name field.
         pool_name = getattr(namespace, "pool_name", None)
@@ -122,6 +125,11 @@ class LogicalActions:
 
         :raises StratisCliEngineError:
         """
+        from ._data import ObjectManager
+        from ._data import Pool
+        from ._data import filesystems
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
 
@@ -152,6 +160,11 @@ class LogicalActions:
 
         :raises StratisCliEngineError:
         """
+        from ._data import ObjectManager
+        from ._data import Pool
+        from ._data import filesystems
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
 
@@ -179,6 +192,11 @@ class LogicalActions:
         """
         Rename a filesystem.
         """
+        from ._data import ObjectManager
+        from ._data import Filesystem
+        from ._data import filesystems
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = next(

--- a/src/stratis_cli/_actions/_physical.py
+++ b/src/stratis_cli/_actions/_physical.py
@@ -23,11 +23,6 @@ from .._stratisd_constants import BLOCK_DEV_TIER_TO_NAME
 from ._connection import get_object
 from ._constants import SECTOR_SIZE
 from ._constants import TOP_OBJECT
-from ._data import devs
-from ._data import pools
-from ._data import MODev
-from ._data import MOPool
-from ._data import ObjectManager
 from ._formatting import print_table
 
 
@@ -44,6 +39,12 @@ class PhysicalActions:
         List devices. If a pool is specified in the namespace, list devices
         for that pool. Otherwise, list all devices for all pools.
         """
+        from ._data import devs
+        from ._data import pools
+        from ._data import MODev
+        from ._data import MOPool
+        from ._data import ObjectManager
+
         # This method is invoked as the default for "stratis blockdev";
         # the namespace may not have a pool_name field.
         pool_name = getattr(namespace, "pool_name", None)

--- a/src/stratis_cli/_actions/_stratis.py
+++ b/src/stratis_cli/_actions/_stratis.py
@@ -19,7 +19,6 @@ from .._stratisd_constants import RedundancyCodes
 
 from ._connection import get_object
 from ._constants import TOP_OBJECT
-from ._data import Manager
 
 
 class StratisActions:
@@ -40,4 +39,6 @@ class StratisActions:
         """
         List the stratisd version.
         """
+        from ._data import Manager
+
         print("%s" % Manager.Properties.Version.Get(get_object(TOP_OBJECT)))

--- a/src/stratis_cli/_actions/_top.py
+++ b/src/stratis_cli/_actions/_top.py
@@ -24,11 +24,6 @@ from .._stratisd_constants import StratisdErrors
 from ._connection import get_object
 from ._constants import TOP_OBJECT
 from ._constants import SECTOR_SIZE
-from ._data import Manager
-from ._data import MOPool
-from ._data import ObjectManager
-from ._data import Pool
-from ._data import pools
 from ._formatting import print_table
 
 
@@ -44,6 +39,8 @@ class TopActions:
 
         :raises StratisCliEngineError:
         """
+        from ._data import Manager
+
         proxy = get_object(TOP_OBJECT)
 
         (_, rc, message) = Manager.Methods.CreatePool(
@@ -65,6 +62,10 @@ class TopActions:
 
         :raises StratisCliEngineError:
         """
+        from ._data import MOPool
+        from ._data import ObjectManager
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
@@ -92,6 +93,10 @@ class TopActions:
 
         :raises StratisCliEngineError:
         """
+        from ._data import Manager
+        from ._data import ObjectManager
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = next(
@@ -112,6 +117,10 @@ class TopActions:
         """
         Rename a pool.
         """
+        from ._data import ObjectManager
+        from ._data import Pool
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = next(
@@ -132,6 +141,10 @@ class TopActions:
         """
         Add specified data devices to a pool.
         """
+        from ._data import ObjectManager
+        from ._data import Pool
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = next(
@@ -151,6 +164,10 @@ class TopActions:
         """
         Add specified cache devices to a pool.
         """
+        from ._data import ObjectManager
+        from ._data import Pool
+        from ._data import pools
+
         proxy = get_object(TOP_OBJECT)
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         (pool_object_path, _) = next(

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -23,8 +23,12 @@ from dbus_client_gen import DbusClientMissingPropertyError
 from dbus_client_gen import DbusClientMissingSearchPropertiesError
 from dbus_client_gen import DbusClientUniqueResultError
 
-from ._actions import interface_name_to_common_name
+from ._actions import BLOCKDEV_INTERFACE
+from ._actions import FILESYSTEM_INTERFACE
+from ._actions import POOL_INTERFACE
+
 from ._errors import StratisCliEngineError
+from ._errors import StratisCliValueError
 
 _DBUS_INTERFACE_MSG = (
     "The version of stratis you are running expects a different "
@@ -32,6 +36,27 @@ _DBUS_INTERFACE_MSG = (
     "you are running a version that requires a newer version of "
     "stratisd than you are running."
 )
+
+
+def _interface_name_to_common_name(interface_name):
+    """
+    Maps a D-Bus interface name to the common name that identifies the type
+    of stratisd thing that the interface represents.
+
+    :param str interface_name: the interface name
+    :returns: a common name
+    :rtype: str
+    """
+    if interface_name == BLOCKDEV_INTERFACE:
+        return "block device"
+
+    if interface_name == FILESYSTEM_INTERFACE:
+        return "filesystem"
+
+    if interface_name == POOL_INTERFACE:
+        return "pool"
+
+    raise StratisCliValueError(interface_name, "interface_name")
 
 
 def get_errors(exc):
@@ -66,7 +91,7 @@ def interpret_errors(errors):
 
         if isinstance(error, DbusClientUniqueResultError) and error.result == []:
             fmt_str = "Most likely you specified a %s which does not exist."
-            return fmt_str % interface_name_to_common_name(error.interface_name)
+            return fmt_str % _interface_name_to_common_name(error.interface_name)
 
         if isinstance(error, DbusClientMissingSearchPropertiesError):
             return _DBUS_INTERFACE_MSG

--- a/tests/whitebox/monkey_patching/test_keyboard_interrupt.py
+++ b/tests/whitebox/monkey_patching/test_keyboard_interrupt.py
@@ -42,6 +42,8 @@ class KeyboardInterruptTestCase(SimTestCase):
             """
             raise KeyboardInterrupt()
 
+        from stratis_cli._actions import _data
+
         # pylint: disable=protected-access
         stratis_cli._actions._data.Manager.Properties.Version.Get = (
             raise_keyboard_interrupt


### PR DESCRIPTION
Resolves: #313.

The primary purpose of this PR is to postpone loading the ```_data.py``` module until stratis has begun executing. This allows the exceptions defined in the ```_errors.py``` module to have been loaded previously, so that if an exception is raised while ```_data.py``` is being loaded, the name of the raised exception is available.

Another consequence is that, if the D-Bus timeout is set by an environment variable, under this design, that environment variable would be read only when needed, i.e, when a D-Bus call was about to be made for the first time by the program. I think there is no compelling reason for eager failure on an invalid D-Bus timeout specification, so that seems fine w/ me.