### PR TITLE
Cleanup blackbox tests

### DIFF
--- a/check.py
+++ b/check.py
@@ -25,8 +25,6 @@ arg_map = {
     "tests/blackbox/testlib": [
         "--reports=no",
         "--disable=I",
-        "--disable=duplicate-code",
-        "--disable=invalid-name",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
     ],
     "tests/whitebox": [

--- a/check.py
+++ b/check.py
@@ -15,13 +15,11 @@ arg_map = {
     "tests/blackbox/stratisd_cert.py": [
         "--reports=no",
         "--disable=I",
-        "--disable=invalid-name",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
     ],
     "tests/blackbox/stratis_cli_cert.py": [
         "--reports=no",
         "--disable=I",
-        "--disable=invalid-name",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
     ],
     "tests/blackbox/testlib": [

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -20,8 +20,8 @@ import sys
 import time
 import unittest
 
-from testlib.utils import exec_command, process_exists
-from testlib.stratis import StratisCli, clean_up
+from testlib.utils import exec_command, exec_test_command, process_exists
+from testlib.stratis import STRATIS_CLI, StratisCli, clean_up
 
 DISKS = []
 
@@ -48,6 +48,17 @@ class StratisCertify(unittest.TestCase):
 
         StratisCli.destroy_all()
         assert StratisCli.pool_list() == []
+
+    def test_stratisd_version(self):
+        """
+        Test getting the daemon version.
+        """
+        exit_code, stdout, stderr = exec_test_command(
+            [STRATIS_CLI, "daemon", "version"]
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr, "")
+        self.assertNotEqual(stdout, "")
 
 
 if __name__ == "__main__":

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -51,11 +51,11 @@ class StratisCertify(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    ap = argparse.ArgumentParser()
-    ap.add_argument(
+    ARGUMENT_PARSER = argparse.ArgumentParser()
+    ARGUMENT_PARSER.add_argument(
         "--disk", action="append", dest="DISKS", help="disks to use", required=True
     )
-    disks, args = ap.parse_known_args()
-    DISKS = disks.DISKS
+    PARSED_ARGS, OTHER_ARGS = ARGUMENT_PARSER.parse_known_args()
+    DISKS = PARSED_ARGS.DISKS
     print("Using block device(s) for tests: %s" % DISKS)
-    unittest.main(argv=sys.argv[:1] + args)
+    unittest.main(argv=sys.argv[:1] + OTHER_ARGS)

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -21,19 +21,9 @@ import time
 import unittest
 
 from testlib.utils import exec_command, process_exists
-from testlib.stratis import StratisCli
+from testlib.stratis import StratisCli, clean_up
 
 DISKS = []
-
-
-def _clean_up():
-    """
-    Try to clean up after a test failure.
-
-    :return: None
-    """
-    StratisCli.destroy_all()
-    assert StratisCli.pool_list() == []
 
 
 class StratisCertify(unittest.TestCase):
@@ -50,7 +40,7 @@ class StratisCertify(unittest.TestCase):
         Stratis filesystems, pools, etc.
         :return: None
         """
-        self.addCleanup(_clean_up)
+        self.addCleanup(clean_up)
 
         if process_exists("stratisd") is None:
             exec_command(["systemctl", "start", "stratisd"])

--- a/tests/blackbox/stratisd_cert.py
+++ b/tests/blackbox/stratisd_cert.py
@@ -16,20 +16,12 @@ Tests of stratisd via the Stratis CLI.
 """
 
 import argparse
-import os
 import sys
 import time
 import unittest
 
-from testlib.utils import (
-    exec_command,
-    process_exists,
-    file_create,
-    file_signature,
-    rs,
-    stratis_link,
-)
-from testlib.stratis import StratisCli, fs_n, p_n
+from testlib.utils import exec_command, process_exists
+from testlib.stratis import StratisCli
 
 DISKS = []
 
@@ -66,168 +58,6 @@ class StratisCertify(unittest.TestCase):
 
         StratisCli.destroy_all()
         assert StratisCli.pool_list() == []
-
-    def test_pool_create(self):
-        """
-        Test pool create.
-        :return: None
-        """
-        pool_name = p_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-        pools = StratisCli.pool_list()
-        self.assertTrue(pool_name in pools)
-        self.assertEqual(1, len(pools))
-
-    def test_pool_rename(self):
-        """
-        Test pool rename
-        :return:
-        """
-        pool_name = p_n()
-        new_name = p_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-        self.assertTrue(pool_name in StratisCli.pool_list())
-        StratisCli.pool_rename(pool_name, new_name)
-        pl = StratisCli.pool_list()
-        self.assertEqual(len(pl), 1)
-        self.assertTrue(new_name in pl)
-
-    def test_pool_destroy(self):
-        """
-        Test destroying a pool
-        :return: None
-        """
-        pool_name = p_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-        StratisCli.pool_destroy(pool_name)
-        pools = StratisCli.pool_list()
-        self.assertFalse(pool_name in pools)
-        self.assertEqual(0, len(pools))
-
-    def test_pool_add_data(self):
-        """
-        Test adding a data device to a pool.
-        :return: None
-        """
-        pool_name = p_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-        StratisCli.pool_add(pool_name, "add-data", DISKS[1:])
-        block_devs = StratisCli.blockdev_list()
-
-        for d in DISKS:
-            self.assertTrue(d in block_devs)
-
-    def test_pool_add_cache(self):
-        """
-        Test adding cache to a pool
-        :return: None
-        """
-        pool_name = p_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-        StratisCli.pool_add(pool_name, "add-cache", DISKS[1:])
-        block_devs = StratisCli.blockdev_list()
-
-        for d in DISKS:
-            self.assertTrue(d in block_devs)
-
-    def test_fs_create(self):
-        """
-        Test creating a FS
-        :return: None
-        """
-        pool_name = p_n()
-        fs_name = fs_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-        StratisCli.fs_create(pool_name, fs_name)
-        fs = StratisCli.fs_list()
-        self.assertTrue(fs_name in fs.keys())
-        self.assertEqual(1, len(fs))
-        self.assertEqual(fs[fs_name]["POOL_NAME"], pool_name)
-
-    def test_fs_destroy(self):
-        """
-        Test destroying a FS
-        :return:
-        """
-        pool_name = p_n()
-        fs_name = fs_n()
-        fs_too = fs_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-        StratisCli.fs_create(pool_name, fs_name)
-        StratisCli.fs_create(pool_name, fs_too)
-        StratisCli.fs_destroy(pool_name, fs_name)
-
-        fs = StratisCli.fs_list()
-        self.assertEqual(1, len(fs))
-        self.assertFalse(fs_n in fs)
-        self.assertTrue(fs_too in fs)
-
-    def test_block_dev_list(self):
-        """
-        Test block device listing
-        :return:
-        """
-        pool_name = p_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-
-        block_devs = StratisCli.blockdev_list()
-        self.assertTrue(DISKS[0] in block_devs)
-        self.assertEqual(1, len(block_devs))
-        self.assertEqual(pool_name, block_devs[DISKS[0]]["POOL_NAME"])
-
-    def test_fs_rename(self):
-        """
-        Test renaming a FS
-        :return: None
-        """
-        pool_name = p_n()
-        fs_name = fs_n()
-        fs_new_name = fs_n()
-        StratisCli.pool_create(pool_name, [DISKS[0]])
-        StratisCli.fs_create(pool_name, fs_name)
-        StratisCli.fs_rename(pool_name, fs_name, fs_new_name)
-
-        fs = StratisCli.fs_list()
-        self.assertTrue(fs_new_name in fs.keys())
-        self.assertFalse(fs_name in fs.keys())
-        self.assertEqual(1, len(fs))
-
-    def test_simple_data_io(self):
-        """
-        Create a pool and fs, create some files on it and validate them to
-        ensure very basic data path is working.
-        :return: None
-        """
-        mount_path = None
-        try:
-            pool_name = p_n()
-            fs_name = fs_n()
-            StratisCli.pool_create(pool_name, block_devices=DISKS)
-            StratisCli.fs_create(pool_name, fs_name)
-
-            # mount the fs
-            mount_path = os.path.join(os.path.sep + "mnt", rs(16))
-            os.mkdir(mount_path)
-            exec_command(["mount", stratis_link(pool_name, fs_name), mount_path])
-
-            files = {}
-            total_size = 0
-            # Do some simple IO to it, creating at most about ~100MiB data
-            while total_size < 1024 * 1024 * 100:
-                fn, signature, size = file_create(mount_path)
-                total_size += size
-                files[fn] = signature
-
-            # Validate them
-            for name, signature in files.items():
-                self.assertTrue(file_signature(name), signature)
-
-        finally:
-            # Make sure we un-mount the fs before we bail as we can't clean up
-            # Stratis when the FS is mounted.
-            if mount_path:
-                exec_command(["umount", mount_path])
-                os.rmdir(mount_path)
 
 
 if __name__ == "__main__":

--- a/tests/blackbox/stratisd_cert.py
+++ b/tests/blackbox/stratisd_cert.py
@@ -51,11 +51,11 @@ class StratisCertify(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    ap = argparse.ArgumentParser()
-    ap.add_argument(
+    ARGUMENT_PARSER = argparse.ArgumentParser()
+    ARGUMENT_PARSER.add_argument(
         "--disk", action="append", dest="DISKS", help="disks to use", required=True
     )
-    disks, args = ap.parse_known_args()
-    DISKS = disks.DISKS
+    PARSED_ARGS, OTHER_ARGS = ARGUMENT_PARSER.parse_known_args()
+    DISKS = PARSED_ARGS.DISKS
     print("Using block device(s) for tests: %s" % DISKS)
-    unittest.main(argv=sys.argv[:1] + args)
+    unittest.main(argv=sys.argv[:1] + OTHER_ARGS)

--- a/tests/blackbox/stratisd_cert.py
+++ b/tests/blackbox/stratisd_cert.py
@@ -20,7 +20,7 @@ import sys
 import time
 import unittest
 
-from testlib.utils import exec_command, process_exists
+from testlib.utils import exec_command, exec_test_command, process_exists
 from testlib.stratis import StratisCli, clean_up
 
 DISKS = []
@@ -48,6 +48,27 @@ class StratisCertify(unittest.TestCase):
 
         StratisCli.destroy_all()
         assert StratisCli.pool_list() == []
+
+    def test_get_managed_objects(self):
+        """
+        Test that GetManagedObjects returns a string w/out failure.
+        """
+        exit_code, stdout, stderr = exec_test_command(
+            [
+                "busctl",
+                "call",
+                "org.storage.stratis1",
+                "/org/storage/stratis1",
+                "org.freedesktop.DBus.ObjectManager",
+                "GetManagedObjects",
+                "--verbose",
+                "--no-pager",
+                "--timeout=1200",
+            ]
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr, "")
+        self.assertNotEqual(stdout, "")
 
 
 if __name__ == "__main__":

--- a/tests/blackbox/stratisd_cert.py
+++ b/tests/blackbox/stratisd_cert.py
@@ -21,19 +21,9 @@ import time
 import unittest
 
 from testlib.utils import exec_command, process_exists
-from testlib.stratis import StratisCli
+from testlib.stratis import StratisCli, clean_up
 
 DISKS = []
-
-
-def _clean_up():
-    """
-    Try to clean up after a test failure.
-
-    :return: None
-    """
-    StratisCli.destroy_all()
-    assert StratisCli.pool_list() == []
 
 
 class StratisCertify(unittest.TestCase):
@@ -50,7 +40,7 @@ class StratisCertify(unittest.TestCase):
         Stratis filesystems, pools, etc.
         :return: None
         """
-        self.addCleanup(_clean_up)
+        self.addCleanup(clean_up)
 
         if process_exists("stratisd") is None:
             exec_command(["systemctl", "start", "stratisd"])

--- a/tests/blackbox/testlib/stratis.py
+++ b/tests/blackbox/testlib/stratis.py
@@ -16,7 +16,7 @@ Wrapper around stratis CLI
 """
 import os
 
-from .utils import exec_command, rs, umount_mdv, stratis_link
+from .utils import exec_command, random_string, umount_mdv, stratis_link
 
 # Some packaged systems might place this in /usr/sbin
 STRATIS_CLI = os.getenv("STRATIS_CLI", "/usr/bin/stratis")
@@ -30,7 +30,7 @@ def p_n():
     Return a random pool name
     :return: Random String
     """
-    return TEST_PREF + "pool" + rs()
+    return TEST_PREF + "pool" + random_string()
 
 
 def fs_n():
@@ -38,7 +38,7 @@ def fs_n():
     Return a random FS name
     :return: Random String
     """
-    return TEST_PREF + "fs" + rs()
+    return TEST_PREF + "fs" + random_string()
 
 
 class StratisCli:

--- a/tests/blackbox/testlib/stratis.py
+++ b/tests/blackbox/testlib/stratis.py
@@ -112,3 +112,13 @@ class StratisCli:
             exec_command([STRATIS_CLI, "fs", "destroy", pool_name, fs_name])
             full_path = stratis_link(pool_name, fs_name)
             assert os.path.exists(full_path) is False
+
+
+def clean_up():
+    """
+    Try to clean up after a test failure.
+
+    :return: None
+    """
+    StratisCli.destroy_all()
+    assert StratisCli.pool_list() == []

--- a/tests/blackbox/testlib/stratis.py
+++ b/tests/blackbox/testlib/stratis.py
@@ -52,7 +52,7 @@ class StratisCli:
         Query the pools
         :return: A list of pool names.
         """
-        lines = exec_command([STRATIS_CLI, "pool", "list"])[0].splitlines()[1:]
+        lines = exec_command([STRATIS_CLI, "pool", "list"]).splitlines()[1:]
 
         return [
             fields[0]
@@ -66,7 +66,7 @@ class StratisCli:
         Query the file systems
         :return: A dict,  Key being the fs name, the value being its pool name.
         """
-        lines = exec_command([STRATIS_CLI, "fs", "list"])[0].splitlines()[1:]
+        lines = exec_command([STRATIS_CLI, "fs", "list"]).splitlines()[1:]
 
         return dict(
             (fields[1], fields[0])

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -81,21 +81,16 @@ def exec_command(cmd):
     :rtype: str
     :raises AssertionError: if exit code is non-zero
     """
-    process = Popen(cmd, stdout=PIPE, stderr=PIPE, close_fds=True, env=os.environ)
-    result = process.communicate()
-    stdout_text = bytes(result[0]).decode("utf-8")
-    stderr_text = bytes(result[1]).decode("utf-8")
+    exit_code, stdout_text, stderr_text = exec_test_command(cmd)
 
     expected_exit_code = 0
 
-    if expected_exit_code != process.returncode:
-        print(
-            "cmd = %s [%d != %d]" % (str(cmd), expected_exit_code, process.returncode)
-        )
+    if expected_exit_code != exit_code:
+        print("cmd = %s [%d != %d]" % (str(cmd), expected_exit_code, exit_code))
         print("STDOUT= %s" % stdout_text)
         print("STDERR= %s" % stderr_text)
 
-    assert expected_exit_code == process.returncode
+    assert expected_exit_code == exit_code
     return stdout_text
 
 

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -31,16 +31,6 @@ def rs(length=4):
     )
 
 
-def size_representation(size, units):
-    """
-    Convert size and units to a string
-    :param size: Size to convert (numeric as a string from CLI output)
-    :param units: Unit designator
-    :return: String with size and units
-    """
-    return size + units
-
-
 def stratis_link(pool_name, fs_name=None):
     """
     Generate the stratis symlink for the pool and optionally for FS

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -92,3 +92,20 @@ def exec_command(cmd, expected_exit_code=0):
 
     assert expected_exit_code == process.returncode
     return stdout_text, stderr_text
+
+
+def exec_test_command(cmd):
+    """
+    Executes the specified test command
+    :param cmd: Command and arguments as list
+    :type cmd: list of str
+    :returns: (exit code, std out text, std err text)
+    :rtype: triple of int * str * str
+    """
+    process = Popen(cmd, stdout=PIPE, stderr=PIPE, close_fds=True, env=os.environ)
+    result = process.communicate()
+    return (
+        process.returncode,
+        bytes(result[0]).decode("utf-8"),
+        bytes(result[1]).decode("utf-8"),
+    )

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -20,7 +20,7 @@ import string
 from subprocess import Popen, PIPE
 
 
-def rs(length=4):
+def random_string(length=4):
     """
     Generates a random string
     :param length: Length of random string
@@ -38,10 +38,10 @@ def stratis_link(pool_name, fs_name=None):
     :param fs_name:
     :return: Full path and name to symlink
     """
-    fp = os.path.join(os.path.sep + "stratis", pool_name)
+    fs_path = os.path.join(os.path.sep + "stratis", pool_name)
     if fs_name:
-        fp = os.path.join(fp, fs_name)
-    return fp
+        fs_path = os.path.join(fs_path, fs_name)
+    return fs_path
 
 
 def process_exists(name):
@@ -49,13 +49,13 @@ def process_exists(name):
     Walk the process table looking for executable 'name', returns pid if one
     found, else return None
     """
-    for p in [pid for pid in os.listdir("/proc") if pid.isdigit()]:
+    for pid in [pid for pid in os.listdir("/proc") if pid.isdigit()]:
         try:
-            exe_name = os.readlink(os.path.join("/proc/", p, "exe"))
+            exe_name = os.readlink(os.path.join("/proc/", pid, "exe"))
         except OSError:
             continue
         if exe_name and exe_name.endswith(os.path.join("/", name)):
-            return p
+            return pid
     return None
 
 
@@ -64,11 +64,11 @@ def umount_mdv():
     Locate and umount any stratis mdv mounts
     :return: None
     """
-    with open("/proc/self/mounts", "r") as f:
-        for l in f.readlines():
-            if "/stratis/.mdv-" in l:
-                mp = l.split()[1]
-                exec_command(["umount", mp])
+    with open("/proc/self/mounts", "r") as mounts:
+        for line in mounts.readlines():
+            if "/stratis/.mdv-" in line:
+                mountpoint = line.split()[1]
+                exec_command(["umount", mountpoint])
 
 
 def exec_command(cmd):

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -71,17 +71,22 @@ def umount_mdv():
                 exec_command(["umount", mp])
 
 
-def exec_command(cmd, expected_exit_code=0):
+def exec_command(cmd):
     """
-    Executes the specified command
-    :param cmd: Command and arguments as list
-    :param expected_exit_code: Integer exit code, will assert if not met
-    :return: (std out text, std err text)
+    Executes the specified infrastructure command.
+
+    :param cmd: command to execute
+    :type cmd: list of str
+    :returns: standard output
+    :rtype: str
+    :raises AssertionError: if exit code is non-zero
     """
     process = Popen(cmd, stdout=PIPE, stderr=PIPE, close_fds=True, env=os.environ)
     result = process.communicate()
     stdout_text = bytes(result[0]).decode("utf-8")
     stderr_text = bytes(result[1]).decode("utf-8")
+
+    expected_exit_code = 0
 
     if expected_exit_code != process.returncode:
         print(
@@ -91,7 +96,7 @@ def exec_command(cmd, expected_exit_code=0):
         print("STDERR= %s" % stderr_text)
 
     assert expected_exit_code == process.returncode
-    return stdout_text, stderr_text
+    return stdout_text
 
 
 def exec_test_command(cmd):

--- a/tests/blackbox/testlib/utils.py
+++ b/tests/blackbox/testlib/utils.py
@@ -14,7 +14,6 @@
 """
 Utility functions for blackbox testing.
 """
-import hashlib
 import os
 import random
 import string
@@ -103,44 +102,3 @@ def exec_command(cmd, expected_exit_code=0):
 
     assert expected_exit_code == process.returncode
     return stdout_text, stderr_text
-
-
-def md5(t):
-    """
-    Generate a md5 signature for t
-    :param t: Data to calculate signature for
-    :return: md5 signature
-    """
-    h = hashlib.md5()
-    h.update(t.encode("utf-8"))
-    return h.hexdigest()
-
-
-# Generate a random buffer once for creating files to speed things up.
-RAND_DATA = rs(1024 * 1024 * 8)
-
-
-def file_create(directory):
-    """
-    Create a random sized file in the specified directory
-    :param directory: Directory to create file in
-    :return: (file name, file signature, file size)
-    """
-    file_name = os.path.join(directory, rs(12))
-    file_size = random.randint(512, len(RAND_DATA))
-    file_data = RAND_DATA[:file_size]
-    signature = md5(file_data)
-    with open(file_name, "w") as f:
-        f.write(file_data)
-    return file_name, signature, file_size
-
-
-def file_signature(file_name):
-    """
-    Return md5 signature for file name
-    :param file_name: File to return md5sum for
-    :return: md5 for file
-    """
-    with open(file_name, "r") as f:
-        file_data = f.read()
-    return md5(file_data)


### PR DESCRIPTION
This PR tidies up the existing blackbox testing infrastructure and inserts two example tests one for stratisd and one for stratis-cli.

It establishes an exec_test_command method to be used to run tests. This method contains no internal assertions, it is expected that the test that calls it will make the assertions about expected behavior and they'll use the appropriate unittest methods to do so.

It simplifies exec_command which is now used only for infrastructure actions, so that it always expects success.

It also fixes up a bunch of pylint errors, taking advantage of the point where the amount of code is a minimum to remove some blanket disables from check.py. It may be necessary to add some of these blanket disables back in again as the test suite is expanded. However, they were all previously grandfathered in from when these files weren't being pylinted, so it may prove not necessary, also.

There are a bunch of StratisCli methods remaining in the stratis module. These are used in the test infrastructure for setting up and cleaning up actions. We must make these methods independent of the daemon and the CLI, especially for the daemon tests, but I'm leaving them alone for now.

It also does not take steps to do any abstractions for either the busctl or the stratis commands although they are likely to be repetitious. This abstraction is also deferred until a later PR. The current tests in both files just constitute reasonable examples to build on.

Related:
https://github.com/stratis-storage/project/issues/45
https://github.com/stratis-storage/project/issues/79
https://github.com/stratis-storage/project/issues/80