### PR TITLE
Fix docs target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ upload-release:
 
 .PHONY: docs
 docs:
-	cd doc/_build/html; zip -r ../../../docs *
+	sphinx-apidoc-3 -P -F -o src/stratis_cli src/stratis_cli
+	sphinx-build-3 -b html src/stratis_cli docs/_build/html
 
 dbus-tests:
 	py.test-3 ${PYTEST_OPTS} ./tests/whitebox/integration


### PR DESCRIPTION
Closes #334 

This does all of the work needed to generate sphinx documentation for the module `stratis_cli`.