### PR TITLE
Add Stratis CLI blackbox tests

### DIFF
--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -82,7 +82,6 @@ class StratisCertify(unittest.TestCase):
     ):
         """
         Execute a test command and make assertions about the exit code, stderr, and stdout
-        :param self: A test object
         :param list args: The arguments needed to execute the Stratis command being tested
         :type args: List of str
         :param exp_exit_code: The expected exit code, 0, 1, or 2

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -39,7 +39,7 @@ def make_test_pool():
 def make_test_filesystem(pool_name):
     """
     Create a test filesystem that will later get destroyed
-    :param name: Name of a test pool
+    :param pool_name: Name of a test pool
     :return: Name of the created filesystem
     """
     filesystem_name = fs_n()
@@ -50,6 +50,45 @@ def make_test_filesystem(pool_name):
         == 0
     )
     return filesystem_name
+
+
+def assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr):
+    """
+    :param self: A test object
+    :param exit_code: An exit code
+    :param stdout: stdout
+    :param stderr: stderr
+    :return: None
+    """
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(stderr, "")
+    self.assertEqual(stdout, "")
+
+
+def assert_test_result_success_stdout_nonempty(self, exit_code, stdout, stderr):
+    """
+    :param self: A test object
+    :param exit_code: An exit code
+    :param stdout: stdout
+    :param stderr: stderr
+    :return: None
+    """
+    self.assertEqual(exit_code, 0)
+    self.assertEqual(stderr, "")
+    self.assertNotEqual(stdout, "")
+
+
+def assert_test_result_failure_stdout_empty(self, exit_code, stdout, stderr):
+    """
+    :param self: A test object
+    :param exit_code: An exit code
+    :param stdout: stdout
+    :param stderr: stderr
+    :return: None
+    """
+    self.assertEqual(exit_code, 1)
+    self.assertNotEqual(stderr, "")
+    self.assertEqual(stdout, "")
 
 
 class StratisCertify(unittest.TestCase):
@@ -82,9 +121,8 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "daemon", "version"]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertNotEqual(stdout, "")
+
+        assert_test_result_success_stdout_nonempty(self, exit_code, stdout, stderr)
 
     def test_stratisd_redundancy(self):
         """
@@ -93,18 +131,16 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "daemon", "redundancy"]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertNotEqual(stdout, "")
+
+        assert_test_result_success_stdout_nonempty(self, exit_code, stdout, stderr)
 
     def test_pool_list_empty(self):
         """
         Test listing a non-existent pool.
         """
         exit_code, stdout, stderr = exec_test_command([STRATIS_CLI, "pool", "list"])
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertNotEqual(stdout, "")
+
+        assert_test_result_success_stdout_nonempty(self, exit_code, stdout, stderr)
 
     def test_filesystem_list_empty(self):
         """
@@ -113,9 +149,8 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "filesystem", "list"]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertNotEqual(stdout, "")
+
+        assert_test_result_success_stdout_nonempty(self, exit_code, stdout, stderr)
 
     def test_pool_create(self):
         """
@@ -126,9 +161,7 @@ class StratisCertify(unittest.TestCase):
             [STRATIS_CLI, "pool", "create", pool_name, DISKS[0]]
         )
 
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_pool_list_not_empty(self):
         """
@@ -137,9 +170,8 @@ class StratisCertify(unittest.TestCase):
         make_test_pool()
 
         exit_code, stdout, stderr = exec_test_command([STRATIS_CLI, "pool", "list"])
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertNotEqual(stdout, "")
+
+        assert_test_result_success_stdout_nonempty(self, exit_code, stdout, stderr)
 
     def test_blockdev_list(self):
         """
@@ -148,9 +180,8 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "blockdev", "list", make_test_pool()]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertNotEqual(stdout, "")
+
+        assert_test_result_success_stdout_nonempty(self, exit_code, stdout, stderr)
 
     def test_pool_create_same_name(self):
         """
@@ -159,9 +190,8 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "pool", "create", make_test_pool(), DISKS[0]]
         )
-        self.assertEqual(exit_code, 1)
-        self.assertNotEqual(stderr, "")
-        self.assertEqual(stdout, "")
+
+        assert_test_result_failure_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_pool_add_cache(self):
         """
@@ -171,9 +201,7 @@ class StratisCertify(unittest.TestCase):
             [STRATIS_CLI, "pool", "add-cache", make_test_pool(), DISKS[1]]
         )
 
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_pool_destroy(self):
         """
@@ -182,9 +210,8 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "pool", "destroy", make_test_pool()]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_filesystem_create(self):
         """
@@ -195,9 +222,7 @@ class StratisCertify(unittest.TestCase):
             [STRATIS_CLI, "filesystem", "create", make_test_pool(), filesystem_name]
         )
 
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_pool_add_data(self):
         """
@@ -207,9 +232,8 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "pool", "add-data", pool_name, DISKS[1]]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_filesystem_list_not_empty(self):
         """
@@ -221,9 +245,8 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "filesystem", "list"]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertNotEqual(stdout, "")
+
+        assert_test_result_success_stdout_nonempty(self, exit_code, stdout, stderr)
 
     def test_filesystem_create_same_name(self):
         """
@@ -236,9 +259,7 @@ class StratisCertify(unittest.TestCase):
             [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
         )
 
-        self.assertEqual(exit_code, 1)
-        self.assertNotEqual(stderr, "")
-        self.assertEqual(stdout, "")
+        assert_test_result_failure_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_filesystem_rename(self):
         """
@@ -258,9 +279,8 @@ class StratisCertify(unittest.TestCase):
                 fs_name_rename,
             ]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_filesystem_rename_same_name(self):
         """
@@ -279,9 +299,8 @@ class StratisCertify(unittest.TestCase):
                 filesystem_name,
             ]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_filesystem_snapshot(self):
         """
@@ -302,9 +321,8 @@ class StratisCertify(unittest.TestCase):
                 snapshot_name,
             ]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
     def test_filesystem_destroy(self):
         """
@@ -316,9 +334,8 @@ class StratisCertify(unittest.TestCase):
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "filesystem", "destroy", pool_name, filesystem_name]
         )
-        self.assertEqual(exit_code, 0)
-        self.assertEqual(stderr, "")
-        self.assertEqual(stdout, "")
+
+        assert_test_result_success_stdout_empty(self, exit_code, stdout, stderr)
 
 
 if __name__ == "__main__":

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -20,8 +20,8 @@ import sys
 import time
 import unittest
 
-from testlib.utils import exec_command, exec_test_command, process_exists
-from testlib.stratis import STRATIS_CLI, StratisCli, clean_up, p_n, fs_n
+from testlib.utils import exec_command, exec_test_command, process_exists, p_n, fs_n
+from testlib.stratis import STRATIS_CLI, StratisCli, clean_up
 
 DISKS = []
 
@@ -85,7 +85,10 @@ class StratisCertify(unittest.TestCase):
         Test listing an existent pool.
         """
         pool_name = p_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
 
         exit_code, stdout, stderr = exec_test_command([STRATIS_CLI, "pool", "list"])
         self.assertEqual(exit_code, 0)
@@ -108,10 +111,16 @@ class StratisCertify(unittest.TestCase):
         Test listing an existent filesystem.
         """
         pool_name = p_n()
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
         filesystem_name = fs_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
-        exec_test_command(
-            [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+        assert (
+            exec_test_command(
+                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+            )[0]
+            == 0
         )
 
         exit_code, stdout, stderr = exec_test_command(
@@ -126,7 +135,10 @@ class StratisCertify(unittest.TestCase):
         Test listing a blockdev.
         """
         pool_name = p_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
 
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "blockdev", "list", pool_name]
@@ -154,7 +166,10 @@ class StratisCertify(unittest.TestCase):
         Test creating a pool that already exists.
         """
         pool_name = p_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
 
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "pool", "create", pool_name, DISKS[0]]
@@ -168,8 +183,11 @@ class StratisCertify(unittest.TestCase):
         Test creating a filesystem.
         """
         pool_name = p_n()
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
         filesystem_name = fs_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
         )
@@ -183,10 +201,16 @@ class StratisCertify(unittest.TestCase):
         Test creating a filesystem that already exists.
         """
         pool_name = p_n()
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
         filesystem_name = fs_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
-        exec_test_command(
-            [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+        assert (
+            exec_test_command(
+                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+            )[0]
+            == 0
         )
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
@@ -201,13 +225,29 @@ class StratisCertify(unittest.TestCase):
         Test renaming a filesystem to a new name.
         """
         pool_name = p_n()
-        fs_name = fs_n()
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
+        filesystem_name = fs_n()
+        assert (
+            exec_test_command(
+                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+            )[0]
+            == 0
+        )
+
         fs_name_rename = fs_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
-        exec_test_command([STRATIS_CLI, "filesystem", "create", pool_name, fs_name])
 
         exit_code, stdout, stderr = exec_test_command(
-            [STRATIS_CLI, "filesystem", "rename", pool_name, fs_name, fs_name_rename]
+            [
+                STRATIS_CLI,
+                "filesystem",
+                "rename",
+                pool_name,
+                filesystem_name,
+                fs_name_rename,
+            ]
         )
         self.assertEqual(exit_code, 0)
         self.assertEqual(stderr, "")
@@ -218,10 +258,16 @@ class StratisCertify(unittest.TestCase):
         Test renaming a filesystem to the same name.
         """
         pool_name = p_n()
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
         filesystem_name = fs_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
-        exec_test_command(
-            [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+        assert (
+            exec_test_command(
+                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+            )[0]
+            == 0
         )
 
         exit_code, stdout, stderr = exec_test_command(
@@ -243,12 +289,19 @@ class StratisCertify(unittest.TestCase):
         Test renaming a filesystem to the same name.
         """
         pool_name = p_n()
-        filesystem_name = fs_n()
-        snapshot_name = "hi"
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
-        exec_test_command(
-            [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
         )
+        filesystem_name = fs_n()
+        assert (
+            exec_test_command(
+                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+            )[0]
+            == 0
+        )
+
+        snapshot_name = fs_n()
 
         exit_code, stdout, stderr = exec_test_command(
             [
@@ -269,7 +322,10 @@ class StratisCertify(unittest.TestCase):
         Test adding data to a pool.
         """
         pool_name = p_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
 
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "pool", "add-data", pool_name, DISKS[1]]
@@ -283,7 +339,10 @@ class StratisCertify(unittest.TestCase):
         Test adding cache to a pool.
         """
         pool_name = p_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
 
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "pool", "add-cache", pool_name, DISKS[1]]
@@ -298,7 +357,10 @@ class StratisCertify(unittest.TestCase):
         Test destroying a pool.
         """
         pool_name = p_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
 
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "pool", "destroy", pool_name]
@@ -312,10 +374,16 @@ class StratisCertify(unittest.TestCase):
         Test destroying a filesystem.
         """
         pool_name = p_n()
+        assert (
+            exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])[0]
+            == 0
+        )
         filesystem_name = fs_n()
-        exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
-        exec_test_command(
-            [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+        assert (
+            exec_test_command(
+                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+            )[0]
+            == 0
         )
 
         exit_code, stdout, stderr = exec_test_command(

--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -28,12 +28,28 @@ DISKS = []
 
 def make_test_pool():
     """
-    Creates a test pool that will later get destroyed
-    return: pool name
+    Create a test pool that will later get destroyed
+    :return: Name of the created pool
     """
     pool_name = p_n()
     exec_test_command([STRATIS_CLI, "pool", "create", pool_name, DISKS[0]])
     return pool_name
+
+
+def make_test_filesystem(pool_name):
+    """
+    Create a test filesystem that will later get destroyed
+    :param name: Name of a test pool
+    :return: Name of the created filesystem
+    """
+    filesystem_name = fs_n()
+    assert (
+        exec_test_command(
+            [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
+        )[0]
+        == 0
+    )
+    return filesystem_name
 
 
 class StratisCertify(unittest.TestCase):
@@ -200,13 +216,7 @@ class StratisCertify(unittest.TestCase):
         Test listing an existent filesystem.
         """
         pool_name = make_test_pool()
-        filesystem_name = fs_n()
-        assert (
-            exec_test_command(
-                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
-            )[0]
-            == 0
-        )
+        make_test_filesystem(pool_name)
 
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "filesystem", "list"]
@@ -220,13 +230,8 @@ class StratisCertify(unittest.TestCase):
         Test creating a filesystem that already exists.
         """
         pool_name = make_test_pool()
-        filesystem_name = fs_n()
-        assert (
-            exec_test_command(
-                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
-            )[0]
-            == 0
-        )
+        filesystem_name = make_test_filesystem(pool_name)
+
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
         )
@@ -240,14 +245,7 @@ class StratisCertify(unittest.TestCase):
         Test renaming a filesystem to a new name.
         """
         pool_name = make_test_pool()
-        filesystem_name = fs_n()
-        assert (
-            exec_test_command(
-                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
-            )[0]
-            == 0
-        )
-
+        filesystem_name = make_test_filesystem(pool_name)
         fs_name_rename = fs_n()
 
         exit_code, stdout, stderr = exec_test_command(
@@ -269,13 +267,7 @@ class StratisCertify(unittest.TestCase):
         Test renaming a filesystem to the same name.
         """
         pool_name = make_test_pool()
-        filesystem_name = fs_n()
-        assert (
-            exec_test_command(
-                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
-            )[0]
-            == 0
-        )
+        filesystem_name = make_test_filesystem(pool_name)
 
         exit_code, stdout, stderr = exec_test_command(
             [
@@ -296,13 +288,7 @@ class StratisCertify(unittest.TestCase):
         Test renaming a filesystem to the same name.
         """
         pool_name = make_test_pool()
-        filesystem_name = fs_n()
-        assert (
-            exec_test_command(
-                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
-            )[0]
-            == 0
-        )
+        filesystem_name = make_test_filesystem(pool_name)
 
         snapshot_name = fs_n()
 
@@ -325,13 +311,7 @@ class StratisCertify(unittest.TestCase):
         Test destroying a filesystem.
         """
         pool_name = make_test_pool()
-        filesystem_name = fs_n()
-        assert (
-            exec_test_command(
-                [STRATIS_CLI, "filesystem", "create", pool_name, filesystem_name]
-            )[0]
-            == 0
-        )
+        filesystem_name = make_test_filesystem(pool_name)
 
         exit_code, stdout, stderr = exec_test_command(
             [STRATIS_CLI, "filesystem", "destroy", pool_name, filesystem_name]


### PR DESCRIPTION
Addresses:  https://github.com/stratis-storage/project/issues/79

The following tests have been added:

- test_stratisd_redundancy
- test_pool_list_empty
- test_filesystem_list_empty
- test_pool_create
- test_pool_list_not_empty
- test_blockdev_list
- test_pool_create_same_name
- test_pool_add_cache
- test_pool_destroy
- test_filesystem_create
- test_pool_add_data
- test_filesystem_list_not_empty
- test_filesystem_create_same_name
- test_filesystem_rename
- test_filesystem_rename_same_name
- test_filesystem_snapshot
- test_filesystem_destroy