### PR TITLE
blackbox: change cli fs_rename_same_name test to verify for failure

### DIFF
--- a/tests/blackbox/stratis_cli_cert.py
+++ b/tests/blackbox/stratis_cli_cert.py
@@ -251,8 +251,8 @@ class StratisCertify(unittest.TestCase):
                 filesystem_name,
                 filesystem_name,
             ],
-            0,
-            True,
+            1,
+            False,
             True,
         )
 


### PR DESCRIPTION
The test_filesystem_rename_same_name test should now verify that
renaming to the same name fails, since the failure return code
on the command line resulted in no action.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>