### PR TITLE
Add StratisCliUserError class

### DIFF
--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -32,10 +32,8 @@ from ._actions import BLOCKDEV_INTERFACE, FILESYSTEM_INTERFACE, POOL_INTERFACE
 from ._errors import (
     StratisCliEngineError,
     StratisCliIncoherenceError,
-    StratisCliInUseError,
-    StratisCliNameConflictError,
-    StratisCliPartialChangeError,
     StratisCliUnknownInterfaceError,
+    StratisCliUserError,
 )
 
 _DBUS_INTERFACE_MSG = (
@@ -129,17 +127,10 @@ def _interpret_errors(errors):
                 "the D-Bus: %s."
             )
             return fmt_str % error
-        if isinstance(error, StratisCliPartialChangeError):
-            fmt_str = "You issued a command that would have a partial or no effect: %s"
+
+        if isinstance(error, StratisCliUserError):
+            fmt_str = "It appears that you issued an unintended command: %s"
             return fmt_str % error
-        if isinstance(error, StratisCliInUseError):
-            fmt_str = (
-                "You issued a command that would have resulted in "
-                "including a block device in both cache and data tiers: %s"
-            )
-            return fmt_str % error
-        if isinstance(error, StratisCliNameConflictError):
-            return str(error)
 
         # An incoherence error should be pretty untestable. It can arise
         # * in the case of a stratisd bug. We would expect to fix that very

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -35,6 +35,12 @@ class StratisCliRuntimeError(StratisCliError):
     """
 
 
+class StratisCliUserError(StratisCliRuntimeError):
+    """
+    Exception raised as a result of a user error.
+    """
+
+
 # This indicates a bug.
 class StratisCliPropertyNotFoundError(StratisCliRuntimeError):
     """
@@ -60,7 +66,7 @@ class StratisCliPropertyNotFoundError(StratisCliRuntimeError):
         )
 
 
-class StratisCliPartialChangeError(StratisCliRuntimeError):
+class StratisCliPartialChangeError(StratisCliUserError):
     """
     Raised if a request made of stratisd must result in a partial or no change
     since some or all of the post-condition for the request already holds.
@@ -124,7 +130,7 @@ class StratisCliNoChangeError(StratisCliPartialChangeError):
         )
 
 
-class StratisCliNameConflictError(StratisCliRuntimeError):
+class StratisCliNameConflictError(StratisCliUserError):
     """
     Raised if an item of the same name already exists.
     """
@@ -154,7 +160,7 @@ class StratisCliIncoherenceError(StratisCliRuntimeError):
     """
 
 
-class StratisCliInUseError(StratisCliRuntimeError):
+class StratisCliInUseError(StratisCliUserError):
     """
     Raised if a request made of stratisd must result in a device being
     included in both data and cache tiers.

--- a/tests/whitebox/unittest/test_error_fmt.py
+++ b/tests/whitebox/unittest/test_error_fmt.py
@@ -23,11 +23,9 @@ import unittest
 from stratis_cli._errors import (
     StratisCliActionError,
     StratisCliEngineError,
-    StratisCliEnvironmentError,
     StratisCliError,
     StratisCliGenerationError,
     StratisCliIncoherenceError,
-    StratisCliNoChangeError,
     StratisCliPropertyNotFoundError,
     StratisCliRuntimeError,
     StratisCliUnknownInterfaceError,
@@ -66,14 +64,6 @@ class ErrorFmtTestCase(unittest.TestCase):
             StratisCliPropertyNotFoundError("BadInterface", "BadProperty")
         )
 
-    def testStratisCliNoChangeErrorFmt(self):
-        """
-        Test 'StratisCliNoChangeError'
-        """
-        self._string_not_empty(
-            StratisCliNoChangeError("Command", frozenset("ChangedResources"))
-        )
-
     def testStratisCliIncoherenceErrorFmt(self):
         """
         Test 'StratisCliIncoherenceError'
@@ -105,9 +95,3 @@ class ErrorFmtTestCase(unittest.TestCase):
         Test 'StratisCliGenerationError'
         """
         self._string_not_empty(StratisCliGenerationError("Error"))
-
-    def testStratisCliEnvironmentErrorFmt(self):
-        """
-        Test 'StratisCliEnvironmentError'
-        """
-        self._string_not_empty(StratisCliEnvironmentError("Error"))


### PR DESCRIPTION
Supersedes #428.
Resolves #426.

Example of StratisCliUserError error message display:

[gchin@to-be-determined stratis-cli]$ sudo PYTHONPATH=./src ./bin/stratis pool create pool1 /dev/sdb1
[gchin@to-be-determined stratis-cli]$ sudo PYTHONPATH=./src ./bin/stratis pool create pool1 /dev/sdb1
Execution failed:
It appears that you issued an unintended command: A pool named pool1 already exists