### PR TITLE
Handle BrokenPipeError

### DIFF
--- a/bin/stratis
+++ b/bin/stratis
@@ -35,6 +35,9 @@ try:
     if __name__ == "__main__":
         main()
 
+except BrokenPipeError:
+    sys.exit("Broken pipe")
+
 except KeyboardInterrupt:
     sys.exit("Received KeyboardInterrupt")
 

--- a/src/stratis_cli/_main.py
+++ b/src/stratis_cli/_main.py
@@ -48,7 +48,13 @@ def run():
             # The same holds for SystemExit, except that it must be allowed
             # to propagate to the interpreter, i.e., it should not be recaught
             # anywhere.
-            except (KeyboardInterrupt, SystemExit, StratisCliEnvironmentError) as err:
+            except (
+                # pylint: disable=bad-continuation
+                BrokenPipeError,
+                KeyboardInterrupt,
+                SystemExit,
+                StratisCliEnvironmentError,
+            ) as err:
                 raise err
             except BaseException as err:
                 raise StratisCliActionError(command_line_args, result) from err


### PR DESCRIPTION
Supersedes: #440.
Resolves: #418.

Demonstration of handled error:
[gchin@to-be-determined stratis-cli]$ sudo PYTHONPATH=./src ./bin/stratis fs list | head
Pool Name  Name                                  Used       Created            Device                                                UUID                            
pool1      b70a1c23-17d9-4ec0-aa01-6902c86e01df  11.77 MiB  Dec 09 2019 15:45  /somepath/pool1/b70a1c23-17d9-4ec0-aa01-6902c86e01df  7ca39d06b7274a549243ae88e39a363f
pool1      a98b02a9-e547-4230-95b8-29654507f009  11.77 MiB  Dec 09 2019 15:47  /somepath/pool1/a98b02a9-e547-4230-95b8-29654507f009  febdddee92984244a1b0783676147d40
pool1      1389f5d6-263d-4955-b089-453e7ead1ef7  11.77 MiB  Dec 09 2019 15:47  /somepath/pool1/1389f5d6-263d-4955-b089-453e7ead1ef7  3e6eb39271494874a1facf76d9cbec8c
pool1      a1cb2349-dc1b-4d42-9d90-58ce497f349a  11.77 MiB  Dec 09 2019 15:47  /somepath/pool1/a1cb2349-dc1b-4d42-9d90-58ce497f349a  0648cccd846f4f719013f9fd6ea0e903
pool1      805dba62-5c01-4a88-b163-1ba8845a5b01  11.77 MiB  Dec 09 2019 15:47  /somepath/pool1/805dba62-5c01-4a88-b163-1ba8845a5b01  bcf83df9fac44fb0bb261d38589b7e65
pool1      379c927e-8dc0-4dc1-8679-861e994503bd  11.77 MiB  Dec 09 2019 15:47  /somepath/pool1/379c927e-8dc0-4dc1-8679-861e994503bd  ad64bbf81bca4ab69fa73b07db16f020
pool1      f6207039-08e4-4af5-afbc-3c2a4577236b  11.77 MiB  Dec 09 2019 15:47  /somepath/pool1/f6207039-08e4-4af5-afbc-3c2a4577236b  05497d58426541d4937a05b7c773f62f
pool1      9e5c5de2-ef4e-46b6-b74a-cd03e338c053  11.77 MiB  Dec 09 2019 15:47  /somepath/pool1/9e5c5de2-ef4e-46b6-b74a-cd03e338c053  6b4dc894d6fa41588490fa9d9810bcee
pool1      2acfe18e-816c-48f9-96ec-e7d887709c45  11.77 MiB  Dec 09 2019 15:47  /somepath/pool1/2acfe18e-816c-48f9-96ec-e7d887709c45  fde1997c8a054ccda56272af3a56608e
Broken pipe
