### PR TITLE
Increase amount of space between columns in printed tables

### DIFF
--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -125,7 +125,7 @@ def _print_row(file, row, row_widths, column_widths, column_alignments):
                 entry, align=column_alignments[index], width=column_len
             )
         )
-    print("  ".join(entries), end="", file=file)
+    print("   ".join(entries), end="", file=file)
 
 
 def print_table(column_headings, row_entries, alignment, file=sys.stdout):


### PR DESCRIPTION
Closes: #443.

Currently, printed tables look like this:
```
Pool Nåme  Nåme  Used     Created            Device                UUID                            
unicode     e      546 MiB  Feb 07 2019 15:33  /stratis/unicode/e    3bf22806a6df4660aa527d646209595f
unicode     ☺      546 MiB  Feb 07 2019 15:33  /stratis/unicode/☺    17101e39e72e423c90d8be5cb37c055b
unicodé    é     546 MiB  Feb 07 2019 15:33  /stratis/unicodé/é  0c2caf641dde41beb40bed6911f75c74
unicodé    漢字     546 MiB  Feb 07 2019 15:33  /stratis/unicodé/漢字  4ecacb15fb64453191d7da731c5f1601
```

This PR would make printed tables look like this:
```
Pool Nåme   Nåme   Used      Created             Device                 UUID                            
unicode      e       546 MiB   Feb 07 2019 15:33   /stratis/unicode/e     3bf22806a6df4660aa527d646209595f
unicode      ☺       546 MiB   Feb 07 2019 15:33   /stratis/unicode/☺     17101e39e72e423c90d8be5cb37c055b
unicodé     é      546 MiB   Feb 07 2019 15:33   /stratis/unicodé/é   0c2caf641dde41beb40bed6911f75c74
unicodé     漢字      546 MiB   Feb 07 2019 15:33   /stratis/unicodé/漢字   4ecacb15fb64453191d7da731c5f1601
```