### PR TITLE
Check error code handling

### DIFF
--- a/bin/stratis
+++ b/bin/stratis
@@ -23,7 +23,7 @@ try:
 
     from stratis_cli import run
     from stratis_cli import StratisCliEnvironmentError
-    from stratis_cli._error_reporting import StratisCliErrorCodes
+    from stratis_cli import StratisCliErrorCodes, exit_
 
     def main():
         """

--- a/bin/stratis
+++ b/bin/stratis
@@ -23,6 +23,7 @@ try:
 
     from stratis_cli import run
     from stratis_cli import StratisCliEnvironmentError
+    from stratis_cli._error_reporting import StratisCliErrorCodes
 
     def main():
         """
@@ -34,10 +35,10 @@ try:
         main()
 
 except BrokenPipeError:
-    sys.exit("Broken pipe")
+    exit_(StratisCliErrorCodes.ERROR, "Broken pipe")
 
 except KeyboardInterrupt:
-    sys.exit("Received KeyboardInterrupt")
+    exit_(StratisCliErrorCodes.ERROR, "Received KeyboardInterrupt")
 
 except StratisCliEnvironmentError as err:
-    sys.exit("Value of STRATIS_DBUS_TIMEOUT invalid: %s" % err)
+    exit_(StratisCliErrorCodes.ERROR, "Value of STRATIS_DBUS_TIMEOUT invalid: %s" % err)

--- a/src/stratis_cli/__init__.py
+++ b/src/stratis_cli/__init__.py
@@ -16,3 +16,4 @@ Top level of CLI.
 """
 from ._main import run
 from ._errors import StratisCliEnvironmentError
+from ._error_reporting import StratisCliErrorCodes

--- a/src/stratis_cli/__init__.py
+++ b/src/stratis_cli/__init__.py
@@ -16,4 +16,4 @@ Top level of CLI.
 """
 from ._main import run
 from ._errors import StratisCliEnvironmentError
-from ._error_reporting import StratisCliErrorCodes, exit_
+from ._error_reporting import StratisCliErrorCodes, handle_error, exit_

--- a/src/stratis_cli/__init__.py
+++ b/src/stratis_cli/__init__.py
@@ -16,4 +16,4 @@ Top level of CLI.
 """
 from ._main import run
 from ._errors import StratisCliEnvironmentError
-from ._error_reporting import StratisCliErrorCodes
+from ._error_reporting import StratisCliErrorCodes, exit_

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -58,9 +58,8 @@ _DBUS_INTERFACE_MSG = (
 
 def exit_(code, msg):
     """
-    Description
+    Exits program with a given exit code and error message.
     """
-    # if msg is not None
     print(msg, file=sys.stderr)
     raise SystemExit(code)
 

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -48,6 +48,8 @@ class StratisCliErrorCodes(IntEnum):
     PARSE_ERROR = 2
 
 
+ERROR = StratisCliErrorCodes.ERROR
+
 _DBUS_INTERFACE_MSG = (
     "The version of stratis you are running expects a different "
     "D-Bus interface than the one stratisd provides. Most likely "
@@ -60,7 +62,7 @@ def exit_(code, msg):
     """
     Exits program with a given exit code and error message.
     """
-    print(msg, file=sys.stderr)
+    print(msg, os.linesep, file=sys.stderr, flush=True)
     raise SystemExit(code)
 
 
@@ -234,4 +236,4 @@ def handle_error(err):
         raise err
 
     exit_msg = "Execution failed:%s%s" % (os.linesep, explanation)
-    exit_(1, exit_msg)
+    exit_(ERROR, exit_msg)

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -62,7 +62,7 @@ def exit_(code, msg):
     """
     # if msg is not None
     print(msg, file=sys.stderr)
-    raise SystemExit(1)
+    raise SystemExit(code)
 
 
 # pylint: disable=fixme
@@ -235,4 +235,4 @@ def handle_error(err):
         raise err
 
     exit_msg = "Execution failed:%s%s" % (os.linesep, explanation)
-    sys.exit(exit_msg)
+    exit_(1, exit_msg)

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -73,6 +73,9 @@ def _interface_name_to_common_name(interface_name):
     :returns: a common name
     :rtype: str
     """
+    # pylint: disable=fixme
+    # FIXME: remove no coverage pragma when adequate testing for CLI output
+    # exists.
     if interface_name == BLOCKDEV_INTERFACE:  # pragma: no cover
         return "block device"
 
@@ -165,6 +168,9 @@ def _interpret_errors(errors):
         # Inspect lowest error
         error = errors[-1]
 
+        # pylint: disable=fixme
+        # FIXME: remove no coverage pragma when adequate testing for CLI output
+        # exists.
         if (
             # pylint: disable=bad-continuation
             isinstance(error, dbus.exceptions.DBusException)
@@ -181,6 +187,9 @@ def _interpret_errors(errors):
         ):
             return "Most likely stratis is unable to connect to the stratisd D-Bus service."
 
+        # pylint: disable=fixme
+        # FIXME: remove no coverage pragma when adequate testing for CLI output
+        # exists.
         if (
             # pylint: disable=bad-continuation
             isinstance(error, dbus.exceptions.DBusException)

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -73,7 +73,7 @@ def _interface_name_to_common_name(interface_name):
     :returns: a common name
     :rtype: str
     """
-    if interface_name == BLOCKDEV_INTERFACE:
+    if interface_name == BLOCKDEV_INTERFACE:  # pragma: no cover
         return "block device"
 
     if interface_name == FILESYSTEM_INTERFACE:
@@ -82,7 +82,7 @@ def _interface_name_to_common_name(interface_name):
     if interface_name == POOL_INTERFACE:
         return "pool"
 
-    raise StratisCliUnknownInterfaceError(interface_name)
+    raise StratisCliUnknownInterfaceError(interface_name)  # pragma: no cover
 
 
 def get_errors(exc):
@@ -168,7 +168,7 @@ def _interpret_errors(errors):
             # pylint: disable=bad-continuation
             isinstance(error, dbus.exceptions.DBusException)
             and error.get_dbus_name() == "org.freedesktop.DBus.Error.AccessDenied"
-        ):
+        ):  # pragma: no cover
             return "Most likely stratis has insufficient permissions for the action requested."
         # We have observed two causes of this problem. The first is that
         # stratisd is not running at all. The second is that stratisd has not
@@ -184,7 +184,7 @@ def _interpret_errors(errors):
             # pylint: disable=bad-continuation
             isinstance(error, dbus.exceptions.DBusException)
             and error.get_dbus_name() == "org.freedesktop.DBus.Error.NoReply"
-        ):
+        ):  # pragma: no cover
             fmt_str = (
                 "stratis attempted communication with the daemon, stratisd, "
                 "over the D-Bus, but stratisd did not respond in the allowed time."

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -17,6 +17,7 @@ Facilities for managing and reporting errors.
 # isort: STDLIB
 import os
 import sys
+from enum import IntEnum
 
 # isort: THIRDPARTY
 import dbus
@@ -35,6 +36,17 @@ from ._errors import (
     StratisCliUnknownInterfaceError,
     StratisCliUserError,
 )
+
+
+class StratisCliErrorCodes(IntEnum):
+    """
+    StratisCli Error Codes
+    """
+
+    OK = 0
+    ERROR = 1
+    PARSE_ERROR = 2
+
 
 _DBUS_INTERFACE_MSG = (
     "The version of stratis you are running expects a different "

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -64,9 +64,7 @@ def exit_(code, msg):
     raise SystemExit(code)
 
 
-# pylint: disable=fixme
-# FIXME: remove no coverage pragma when adequate testing for CLI output exists.
-def _interface_name_to_common_name(interface_name):  # pragma: no cover
+def _interface_name_to_common_name(interface_name):
     """
     Maps a D-Bus interface name to the common name that identifies the type
     of stratisd thing that the interface represents.
@@ -111,9 +109,6 @@ def _interpret_errors(errors):
     :type errors: list of Exception
     :returns: None if no interpretation found, otherwise str
     """
-    # pylint: disable=fixme
-    # FIXME: remove no coverage pragma when adequate testing for CLI output
-    # exists.
     try:
         # Inspect top-most error after StratisCliActionError
         error = errors[1]

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -82,6 +82,7 @@ def _interface_name_to_common_name(interface_name):
     if interface_name == POOL_INTERFACE:
         return "pool"
 
+    # This is a permanent no cover. There should never be an unknown interface.
     raise StratisCliUnknownInterfaceError(interface_name)  # pragma: no cover
 
 

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -48,8 +48,6 @@ class StratisCliErrorCodes(IntEnum):
     PARSE_ERROR = 2
 
 
-ERROR = StratisCliErrorCodes.ERROR
-
 _DBUS_INTERFACE_MSG = (
     "The version of stratis you are running expects a different "
     "D-Bus interface than the one stratisd provides. Most likely "
@@ -236,4 +234,4 @@ def handle_error(err):
         raise err
 
     exit_msg = "Execution failed:%s%s" % (os.linesep, explanation)
-    exit_(ERROR, exit_msg)
+    exit_(StratisCliErrorCodes.ERROR, exit_msg)

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -56,6 +56,15 @@ _DBUS_INTERFACE_MSG = (
 )
 
 
+def exit_(code, msg):
+    """
+    Description
+    """
+    # if msg is not None
+    print(msg, file=sys.stderr)
+    raise SystemExit(1)
+
+
 # pylint: disable=fixme
 # FIXME: remove no coverage pragma when adequate testing for CLI output exists.
 def _interface_name_to_common_name(interface_name):  # pragma: no cover

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -114,7 +114,7 @@ def _interpret_errors(errors):
     # pylint: disable=fixme
     # FIXME: remove no coverage pragma when adequate testing for CLI output
     # exists.
-    try:  # pragma: no cover
+    try:
         # Inspect top-most error after StratisCliActionError
         error = errors[1]
 

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -330,7 +330,7 @@ class StratisCliActionError(StratisCliRuntimeError):
         self.command_line_args = command_line_args
         self.namespace = namespace
 
-    def __str__(self):
+    def __str__(self):  # pragma: no cover
         fmt_str = (
             "Action selected by command-line arguments %s which were "
             "parsed to %s failed"

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -331,7 +331,7 @@ class StratisCliActionError(StratisCliRuntimeError):
         self.namespace = namespace
 
     # pylint: disable=fixme
-    # FIXME
+    # FIXME: remove no coverage pragma when adequate testing for CLI output
     def __str__(self):  # pragma: no cover
         fmt_str = (
             "Action selected by command-line arguments %s which were "

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -330,6 +330,8 @@ class StratisCliActionError(StratisCliRuntimeError):
         self.command_line_args = command_line_args
         self.namespace = namespace
 
+    # pylint: disable=fixme
+    # FIXME
     def __str__(self):  # pragma: no cover
         fmt_str = (
             "Action selected by command-line arguments %s which were "

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -42,16 +42,15 @@ def check_error(obj, expected_err, expected_cause, command_line, expected_code):
     Check that the expected exception was raised, and that the cause
     and exit codes where also as expected, based on the command line arguments
     passed to the program.
-    
-    :param obj: the SimTestCase class 
+    :param obj: the SimTestCase class
     :type obj: SimTestCase ?
     :param expected_err: the top level exception in the chain that is expected
-    :type expecter_err: Exception ? 
+    :type expecter_err: Exception ?
     :param expected_cause: the cause of the top level exception
     :type expected_cause: Exception ?
-    :param command_line: the command line arguments 
+    :param command_line: the command line arguments
     :param expected_code: the error code expected
-    :type expected_code: IntEnum ? 
+    :type expected_code: IntEnum ?
     """
     with obj.assertRaises(expected_err) as context:
         RUNNER(command_line)

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -43,7 +43,9 @@ def check_error(obj, expected_cause, command_line, expected_code):
     Check that the expected exception was raised, and that the cause
     and exit codes where also as expected, based on the command line arguments
     passed to the program.
-    :param expected_cause: the expected cause of the top level exception
+    :param obj: the instance of a unit test
+    :type obj: unittest.TestCase
+    :param expected_cause: the expected exception below the StratisCliActionError
     :type expected_cause: Exception
     :param command_line: the command line arguments
     :type command_line: list

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -20,6 +20,7 @@ import os
 import random
 import string
 import subprocess
+import sys
 import time
 import unittest
 
@@ -27,16 +28,13 @@ import unittest
 import psutil
 
 # isort: LOCAL
-from stratis_cli import exit_, run
-from stratis_cli._error_reporting import StratisCliErrorCodes
-
-ERROR = StratisCliErrorCodes.ERROR
+from stratis_cli import run
 
 try:
     _STRATISD = os.environ["STRATISD"]
 except KeyError:
     message = "STRATISD environment variable must be set to absolute path of stratisd executable"
-    exit_(ERROR, message)
+    sys.exit(message)
 
 
 def device_name_list(min_devices=0, max_devices=10):

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -28,7 +28,7 @@ import unittest
 import psutil
 
 # isort: LOCAL
-from stratis_cli import run, handle_error
+from stratis_cli import handle_error, run
 
 try:
     _STRATISD = os.environ["STRATISD"]

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -88,11 +88,10 @@ class RunTestCase(unittest.TestCase):
     Test case for running the program.
     """
 
-    # is command_line needed as a parameter?
     def check_error(self, expected_cause, command_line, expected_code):
         """
         Check that the expected exception was raised, and that the cause
-        and exit codes where also as expected, based on the command line
+        and exit codes were also as expected, based on the command line
         arguments passed to the program.
         :param expected_cause: the expected exception below the StratisCliActionError
         :type expected_cause: Exception

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -20,7 +20,6 @@ import os
 import random
 import string
 import subprocess
-import sys
 import time
 import unittest
 
@@ -28,7 +27,7 @@ import unittest
 import psutil
 
 # isort: LOCAL
-from stratis_cli import run
+from stratis_cli import exit_, run
 from stratis_cli._error_reporting import StratisCliErrorCodes
 
 ERROR = StratisCliErrorCodes.ERROR

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -29,6 +29,7 @@ import psutil
 
 # isort: LOCAL
 from stratis_cli import handle_error, run
+from stratis_cli._errors import StratisCliActionError
 
 try:
     _STRATISD = os.environ["STRATISD"]
@@ -37,27 +38,27 @@ except KeyError:
     sys.exit(message)
 
 
-def check_error(obj, expected_err, expected_cause, command_line, expected_code):
+def check_error(obj, expected_cause, command_line, expected_code):
     """
     Check that the expected exception was raised, and that the cause
     and exit codes where also as expected, based on the command line arguments
     passed to the program.
-    :param expected_err: the expected top level exception in the chain
-    :type expecter_err: StratisCliError
     :param expected_cause: the expected cause of the top level exception
-    :type expected_cause: StratisCliError
+    :type expected_cause: Exception
     :param command_line: the command line arguments
+    :type command_line: list
     :param expected_code: the expected error code
     :type expected_code: int
     """
-    with obj.assertRaises(expected_err) as context:
+    with obj.assertRaises(StratisCliActionError) as context:
         RUNNER(command_line)
 
-    cause = context.exception.__cause__
+    exception = context.exception
+    cause = exception.__cause__
     obj.assertIsInstance(cause, expected_cause)
 
     with obj.assertRaises(SystemExit) as final_err:
-        handle_error(context.exception)
+        handle_error(exception)
 
     final_code = final_err.exception.code
     obj.assertEqual(final_code, expected_code)

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -28,7 +28,7 @@ import unittest
 import psutil
 
 # isort: LOCAL
-from stratis_cli import handle_error, run
+from stratis_cli import StratisCliErrorCodes, handle_error, run
 from stratis_cli._errors import StratisCliActionError
 
 try:
@@ -136,6 +136,49 @@ class SimTestCase(unittest.TestCase):
         self._service = _Service()
         self.addCleanup(self._service.cleanup)
         self._service.setUp()
+
+
+class RunTestCase(unittest.TestCase):
+    """
+    Description
+    """
+
+    # is command_line needed as a parameter?
+    def check_error(self, expected_cause, command_line, expected_code):
+        """
+        Check that the expected exception was raised, and that the cause
+        and exit codes where also as expected, based on the command line
+        arguments passed to the program.
+        :param expected_cause: the expected exception below the StratisCliActionError
+        :type expected_cause: Exception
+        :param command_line: the command line arguments
+        :type command_line: list
+        :param expected_code: the expected error code
+        :type expected_code: int
+        """
+        with self.assertRaises(StratisCliActionError) as context:
+            RUNNER(command_line)
+
+        exception = context.exception
+        cause = exception.__cause__
+        self.assertIsInstance(cause, expected_cause)
+
+        with self.assertRaises(SystemExit) as final_err:
+            handle_error(exception)
+
+        final_code = final_err.exception.code
+        self.assertEqual(final_code, expected_code)
+
+    def check_parse_error(self, command_line):
+        """
+        Description
+        :param command_line: the command line arguments
+        :type command_line: list
+        """
+        with self.assertRaises(SystemExit) as context:
+            RUNNER(command_line)
+        exit_code = context.exception.code
+        self.assertEqual(exit_code, StratisCliErrorCodes.PARSE_ERROR)
 
 
 RUNNER = run()

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -111,33 +111,6 @@ class _Service:
             self.tearDown()
 
 
-class SimTestCase(unittest.TestCase):
-    """
-    A SimTestCase must always start and stop stratisd (simulator vesion).
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        """
-        Assert that there are no other stratisd processes running.
-        """
-        for pid in psutil.pids():
-            try:
-                assert psutil.Process(pid).name() != "stratisd", (
-                    "Evidently a stratisd process with process id %u is running" % pid
-                )
-            except psutil.NoSuchProcess:
-                pass
-
-    def setUp(self):
-        """
-        Start the stratisd daemon with the simulator.
-        """
-        self._service = _Service()
-        self.addCleanup(self._service.cleanup)
-        self._service.setUp()
-
-
 class RunTestCase(unittest.TestCase):
     """
     Description
@@ -179,6 +152,33 @@ class RunTestCase(unittest.TestCase):
             RUNNER(command_line)
         exit_code = context.exception.code
         self.assertEqual(exit_code, StratisCliErrorCodes.PARSE_ERROR)
+
+
+class SimTestCase(RunTestCase):
+    """
+    A SimTestCase must always start and stop stratisd (simulator vesion).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Assert that there are no other stratisd processes running.
+        """
+        for pid in psutil.pids():
+            try:
+                assert psutil.Process(pid).name() != "stratisd", (
+                    "Evidently a stratisd process with process id %u is running" % pid
+                )
+            except psutil.NoSuchProcess:
+                pass
+
+    def setUp(self):
+        """
+        Start the stratisd daemon with the simulator.
+        """
+        self._service = _Service()
+        self.addCleanup(self._service.cleanup)
+        self._service.setUp()
 
 
 RUNNER = run()

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -42,15 +42,13 @@ def check_error(obj, expected_err, expected_cause, command_line, expected_code):
     Check that the expected exception was raised, and that the cause
     and exit codes where also as expected, based on the command line arguments
     passed to the program.
-    :param obj: the SimTestCase class
-    :type obj: SimTestCase ?
-    :param expected_err: the top level exception in the chain that is expected
-    :type expecter_err: Exception ?
-    :param expected_cause: the cause of the top level exception
-    :type expected_cause: Exception ?
+    :param expected_err: the expected top level exception in the chain
+    :type expecter_err: StratisCliError
+    :param expected_cause: the expected cause of the top level exception
+    :type expected_cause: StratisCliError
     :param command_line: the command line arguments
-    :param expected_code: the error code expected
-    :type expected_code: IntEnum ?
+    :param expected_code: the expected error code
+    :type expected_code: int
     """
     with obj.assertRaises(expected_err) as context:
         RUNNER(command_line)

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -42,6 +42,16 @@ def check_error(obj, expected_err, expected_cause, command_line, expected_code):
     Check that the expected exception was raised, and that the cause
     and exit codes where also as expected, based on the command line arguments
     passed to the program.
+    
+    :param obj: the SimTestCase class 
+    :type obj: SimTestCase ?
+    :param expected_err: the top level exception in the chain that is expected
+    :type expecter_err: Exception ? 
+    :param expected_cause: the cause of the top level exception
+    :type expected_cause: Exception ?
+    :param command_line: the command line arguments 
+    :param expected_code: the error code expected
+    :type expected_code: IntEnum ? 
     """
     with obj.assertRaises(expected_err) as context:
         RUNNER(command_line)

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -114,7 +114,7 @@ class RunTestCase(unittest.TestCase):
         final_code = final_err.exception.code
         self.assertEqual(final_code, expected_code)
 
-    def check_parse_error(self, command_line, expected_code):
+    def check_system_exit(self, command_line, expected_code):
         """
         Check that SystemExit exception was raised with the expected error
         code as a result of running the program.

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -28,7 +28,7 @@ import unittest
 import psutil
 
 # isort: LOCAL
-from stratis_cli import run
+from stratis_cli import run, handle_error
 
 try:
     _STRATISD = os.environ["STRATISD"]
@@ -50,11 +50,10 @@ def check_error(obj, expected_err, expected_cause, command_line, expected_code):
     obj.assertIsInstance(cause, expected_cause)
 
     with obj.assertRaises(SystemExit) as final_err:
-        handle_error(exception)
+        handle_error(context.exception)
 
     final_code = final_err.exception.code
     obj.assertEqual(final_code, expected_code)
-
 
 
 def device_name_list(min_devices=0, max_devices=10):

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -37,6 +37,26 @@ except KeyError:
     sys.exit(message)
 
 
+def check_error(obj, expected_err, expected_cause, command_line, expected_code):
+    """
+    Check that the expected exception was raised, and that the cause
+    and exit codes where also as expected, based on the command line arguments
+    passed to the program.
+    """
+    with obj.assertRaises(expected_err) as context:
+        RUNNER(command_line)
+
+    cause = context.exception.__cause__
+    obj.assertIsInstance(cause, expected_cause)
+
+    with obj.assertRaises(SystemExit) as final_err:
+        handle_error(exception)
+
+    final_code = final_err.exception.code
+    obj.assertEqual(final_code, expected_code)
+
+
+
 def device_name_list(min_devices=0, max_devices=10):
     """
     Return a function that returns a random list of device names based on

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -113,7 +113,7 @@ class _Service:
 
 class RunTestCase(unittest.TestCase):
     """
-    Description
+    Test case for running the program.
     """
 
     # is command_line needed as a parameter?
@@ -144,9 +144,13 @@ class RunTestCase(unittest.TestCase):
 
     def check_parse_error(self, command_line, expected_code):
         """
-        Description
+        Check that SystemExit exception was raised with the expected error
+        code as a result of running the program.
+
         :param command_line: the command line arguments
         :type command_line: list
+        :param expected_code: the expected error code
+        :type expected_code: int
         """
         with self.assertRaises(SystemExit) as context:
             RUNNER(command_line)

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -28,7 +28,7 @@ import unittest
 import psutil
 
 # isort: LOCAL
-from stratis_cli import StratisCliErrorCodes, handle_error, run
+from stratis_cli import handle_error, run
 from stratis_cli._errors import StratisCliActionError
 
 try:
@@ -142,7 +142,7 @@ class RunTestCase(unittest.TestCase):
         final_code = final_err.exception.code
         self.assertEqual(final_code, expected_code)
 
-    def check_parse_error(self, command_line):
+    def check_parse_error(self, command_line, expected_code):
         """
         Description
         :param command_line: the command line arguments
@@ -151,7 +151,7 @@ class RunTestCase(unittest.TestCase):
         with self.assertRaises(SystemExit) as context:
             RUNNER(command_line)
         exit_code = context.exception.code
-        self.assertEqual(exit_code, StratisCliErrorCodes.PARSE_ERROR)
+        self.assertEqual(exit_code, expected_code)
 
 
 class SimTestCase(RunTestCase):

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -29,12 +29,15 @@ import psutil
 
 # isort: LOCAL
 from stratis_cli import run
+from stratis_cli._error_reporting import StratisCliErrorCodes
+
+ERROR = StratisCliErrorCodes.ERROR
 
 try:
     _STRATISD = os.environ["STRATISD"]
 except KeyError:
     message = "STRATISD environment variable must be set to absolute path of stratisd executable"
-    sys.exit(message)
+    exit_(ERROR, message)
 
 
 def device_name_list(min_devices=0, max_devices=10):

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -35,7 +35,7 @@ from .._misc import RUNNER, SimTestCase, device_name_list
 _DEVICE_STRATEGY = device_name_list(1)
 
 
-def checkHandleError(obj, context):
+def check_handle_error(obj, context):
     with obj.assertRaises(SystemExit) as final_err:
         handle_error(context.exception)
     final_code = final_err.exception.code
@@ -151,7 +151,7 @@ class Create4TestCase(SimTestCase):
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:2]
         with self.assertRaises(StratisCliActionError) as context:
             RUNNER(command_line)
-        checkHandleError(self, context)
+        check_handle_error(self, context)
 
     def test2Create(self):
         """

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -158,11 +158,13 @@ class Create4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )
 
 
 class Create5TestCase(SimTestCase):

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -214,8 +214,10 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:4]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -23,16 +23,12 @@ from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import (
-    StratisCliActionError,
-    StratisCliEngineError,
-    StratisCliPartialChangeError,
-)
+from stratis_cli._errors import StratisCliEngineError, StratisCliPartialChangeError
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
-ERROR = StratisCliErrorCodes.ERROR
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -50,13 +46,7 @@ class CreateTestCase(SimTestCase):
         Creation of the volume must fail since pool is not specified.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -111,9 +101,7 @@ class Create3TestCase(SimTestCase):
         volume of the same name.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        check_error(
-            self, StratisCliActionError, StratisCliEngineError, command_line, ERROR
-        )
+        check_error(self, StratisCliEngineError, command_line, _ERROR)
 
 
 class Create4TestCase(SimTestCase):
@@ -143,13 +131,7 @@ class Create4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:2]
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Create(self):
         """
@@ -158,13 +140,7 @@ class Create4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
 
 
 class Create5TestCase(SimTestCase):
@@ -199,13 +175,7 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Create(self):
         """
@@ -214,10 +184,4 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:4]
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -22,6 +22,7 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli._error_reporting import handle_error
 from stratis_cli._errors import (
     StratisCliActionError,
     StratisCliEngineError,
@@ -32,6 +33,14 @@ from stratis_cli._stratisd_constants import StratisdErrors
 from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+
+
+def checkHandleError(obj, context):
+    with obj.assertRaises(SystemExit) as final_err:
+        handle_error(context.exception)
+    final_code = final_err.exception.code
+    obj.assertIsInstance(final_code, str)
+    obj.assertNotEqual(final_code, "")
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -143,9 +152,7 @@ class Create4TestCase(SimTestCase):
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:2]
         with self.assertRaises(StratisCliActionError) as context:
             RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        checkHandleError(self, context)
 
     def test2Create(self):
         """

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -22,7 +22,7 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._error_reporting import handle_error
+from stratis_cli._error_reporting import StratisCliErrorCodes, handle_error
 from stratis_cli._errors import (
     StratisCliActionError,
     StratisCliEngineError,
@@ -33,13 +33,14 @@ from stratis_cli._stratisd_constants import StratisdErrors
 from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+ERROR = StratisCliErrorCodes.ERROR
 
 
-def check_handle_error(obj, context):
+def check_handle_error(obj, context, expected_code):
     with obj.assertRaises(SystemExit) as final_err:
         handle_error(context.exception)
     final_code = final_err.exception.code
-    obj.assertEqual(final_code, 1)
+    obj.assertEqual(final_code, expected_code)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -151,7 +152,7 @@ class Create4TestCase(SimTestCase):
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:2]
         with self.assertRaises(StratisCliActionError) as context:
             RUNNER(command_line)
-        check_handle_error(self, context)
+        check_handle_error(self, context, ERROR)
 
     def test2Create(self):
         """

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -22,7 +22,7 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._error_reporting import StratisCliErrorCodes
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import (
     StratisCliActionError,
     StratisCliEngineError,

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -51,10 +51,13 @@ class CreateTestCase(SimTestCase):
         Creation of the volume must fail since pool is not specified.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -28,7 +28,6 @@ from stratis_cli._errors import (
     StratisCliEngineError,
     StratisCliPartialChangeError,
 )
-from stratis_cli._stratisd_constants import StratisdErrors
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
@@ -112,11 +111,9 @@ class Create3TestCase(SimTestCase):
         volume of the same name.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        with self.assertRaises(StratisCliEngineError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliEngineError)
-        self.assertEqual(cause.rc, StratisdErrors.ALREADY_EXISTS)
+        check_error(
+            self, StratisCliActionError, StratisCliEngineError, command_line, ERROR
+        )
 
 
 class Create4TestCase(SimTestCase):

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -199,11 +199,13 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )
 
     def test2Create(self):
         """

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -36,14 +36,14 @@ _DEVICE_STRATEGY = device_name_list(1)
 ERROR = StratisCliErrorCodes.ERROR
 
 
-def check_handle_error(obj, context, expected_code):
+def check_handle_error(obj, exception, expected_code):
     """
     Test that exceptions are handled correctly by confirming that the correct
     exception and exit code are returned.
     """
 
     with obj.assertRaises(SystemExit) as final_err:
-        handle_error(context.exception)
+        handle_error(exception)
     final_code = final_err.exception.code
     obj.assertEqual(final_code, expected_code)
 
@@ -157,7 +157,9 @@ class Create4TestCase(SimTestCase):
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:2]
         with self.assertRaises(StratisCliActionError) as context:
             RUNNER(command_line)
-        check_handle_error(self, context, ERROR)
+        check_handle_error(self, context.exception, ERROR)
+        cause = context.exception.__cause__
+        self.assertIsInstance(cause, StratisCliPartialChangeError)
 
     def test2Create(self):
         """

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -39,8 +39,7 @@ def checkHandleError(obj, context):
     with obj.assertRaises(SystemExit) as final_err:
         handle_error(context.exception)
     final_code = final_err.exception.code
-    obj.assertIsInstance(final_code, str)
-    obj.assertNotEqual(final_code, "")
+    obj.assertEqual(final_code, 1)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -22,7 +22,7 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._error_reporting import StratisCliErrorCodes, handle_error
+from stratis_cli._error_reporting import StratisCliErrorCodes
 from stratis_cli._errors import (
     StratisCliActionError,
     StratisCliEngineError,
@@ -30,22 +30,10 @@ from stratis_cli._errors import (
 )
 from stratis_cli._stratisd_constants import StratisdErrors
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 ERROR = StratisCliErrorCodes.ERROR
-
-
-def check_handle_error(obj, exception, expected_code):
-    """
-    Test that exceptions are handled correctly by confirming that the correct
-    exception and exit code are returned.
-    """
-
-    with obj.assertRaises(SystemExit) as final_err:
-        handle_error(exception)
-    final_code = final_err.exception.code
-    obj.assertEqual(final_code, expected_code)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -155,11 +143,13 @@ class Create4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:2]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        check_handle_error(self, context.exception, ERROR)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )
 
     def test2Create(self):
         """

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -37,6 +37,11 @@ ERROR = StratisCliErrorCodes.ERROR
 
 
 def check_handle_error(obj, context, expected_code):
+    """
+    Test that exceptions are handled correctly by confirming that the correct
+    exception and exit code are returned.
+    """
+
     with obj.assertRaises(SystemExit) as final_err:
         handle_error(context.exception)
     final_code = final_err.exception.code

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -25,7 +25,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliEngineError, StratisCliPartialChangeError
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _ERROR = StratisCliErrorCodes.ERROR
@@ -46,7 +46,7 @@ class CreateTestCase(SimTestCase):
         Creation of the volume must fail since pool is not specified.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -101,7 +101,7 @@ class Create3TestCase(SimTestCase):
         volume of the same name.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        check_error(self, StratisCliEngineError, command_line, _ERROR)
+        self.check_error(StratisCliEngineError, command_line, _ERROR)
 
 
 class Create4TestCase(SimTestCase):
@@ -131,7 +131,7 @@ class Create4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:2]
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Create(self):
         """
@@ -140,7 +140,7 @@ class Create4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
 
 class Create5TestCase(SimTestCase):
@@ -175,7 +175,7 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Create(self):
         """
@@ -184,4 +184,4 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:4]
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_destroy.py
+++ b/tests/whitebox/integration/logical/test_destroy.py
@@ -23,12 +23,12 @@ from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import StratisCliActionError, StratisCliPartialChangeError
+from stratis_cli._errors import StratisCliPartialChangeError
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
-ERROR = StratisCliErrorCodes.ERROR
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -47,13 +47,7 @@ class DestroyTestCase(SimTestCase):
         Destruction of the volume must fail since pool is not specified.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -143,13 +137,7 @@ class Destroy4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Destroy(self):
         """
@@ -158,13 +146,7 @@ class Destroy4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
 
 
 class Create5TestCase(SimTestCase):
@@ -199,13 +181,7 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Destroy(self):
         """
@@ -214,10 +190,4 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:4]
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_destroy.py
+++ b/tests/whitebox/integration/logical/test_destroy.py
@@ -22,11 +22,13 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError, StratisCliPartialChangeError
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+ERROR = StratisCliErrorCodes.ERROR
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -45,10 +47,13 @@ class DestroyTestCase(SimTestCase):
         Destruction of the volume must fail since pool is not specified.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -138,11 +143,13 @@ class Destroy4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )
 
     def test2Destroy(self):
         """
@@ -151,11 +158,13 @@ class Destroy4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )
 
 
 class Create5TestCase(SimTestCase):
@@ -190,11 +199,13 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )
 
     def test2Destroy(self):
         """
@@ -203,8 +214,10 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:4]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )

--- a/tests/whitebox/integration/logical/test_destroy.py
+++ b/tests/whitebox/integration/logical/test_destroy.py
@@ -25,7 +25,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliPartialChangeError
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _ERROR = StratisCliErrorCodes.ERROR
@@ -47,7 +47,7 @@ class DestroyTestCase(SimTestCase):
         Destruction of the volume must fail since pool is not specified.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -137,7 +137,7 @@ class Destroy4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Destroy(self):
         """
@@ -146,7 +146,7 @@ class Destroy4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
 
 class Create5TestCase(SimTestCase):
@@ -181,7 +181,7 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Destroy(self):
         """
@@ -190,4 +190,4 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:4]
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_list.py
+++ b/tests/whitebox/integration/logical/test_list.py
@@ -23,7 +23,6 @@ from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import StratisCliActionError
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
@@ -44,11 +43,7 @@ class ListTestCase(SimTestCase):
         """
         command_line = self._MENU + [self._POOLNAME]
         check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            StratisCliErrorCodes.ERROR,
+            self, DbusClientUniqueResultError, command_line, StratisCliErrorCodes.ERROR
         )
 
 

--- a/tests/whitebox/integration/logical/test_list.py
+++ b/tests/whitebox/integration/logical/test_list.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test 'create'.
+Test 'list'.
 """
 
 # isort: STDLIB
@@ -22,9 +22,10 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 
@@ -42,10 +43,13 @@ class ListTestCase(SimTestCase):
         Listing the volume must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            StratisCliErrorCodes.ERROR,
+        )
 
 
 class List2TestCase(SimTestCase):

--- a/tests/whitebox/integration/logical/test_list.py
+++ b/tests/whitebox/integration/logical/test_list.py
@@ -24,7 +24,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 
@@ -42,8 +42,8 @@ class ListTestCase(SimTestCase):
         Listing the volume must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME]
-        check_error(
-            self, DbusClientUniqueResultError, command_line, StratisCliErrorCodes.ERROR
+        self.check_error(
+            DbusClientUniqueResultError, command_line, StratisCliErrorCodes.ERROR
         )
 
 

--- a/tests/whitebox/integration/logical/test_rename.py
+++ b/tests/whitebox/integration/logical/test_rename.py
@@ -25,7 +25,7 @@ from stratis_cli._errors import StratisCliNoChangeError
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
-ERROR = StratisCliErrorCodes.ERROR
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class RenameTestCase(SimTestCase):
@@ -62,7 +62,7 @@ class RenameTestCase(SimTestCase):
         Renaming the filesystem must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        check_error(self, StratisCliNoChangeError, command_line, ERROR)
+        check_error(self, StratisCliNoChangeError, command_line, _ERROR)
 
 
 class Rename1TestCase(SimTestCase):
@@ -81,14 +81,14 @@ class Rename1TestCase(SimTestCase):
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
 
-        check_error(self, DbusClientUniqueResultError, command_line, ERROR)
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
     def testNonExistentPoolSameName(self):
         """
         Renaming the filesystem must fail, because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, ERROR)
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Rename2TestCase(SimTestCase):
@@ -114,11 +114,11 @@ class Rename2TestCase(SimTestCase):
         Renaming the filesystem must fail, because filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, ERROR)
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
     def testNonExistentFilesystemSameName(self):
         """
         Renaming the filesystem must fail, because the filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, ERROR)
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_rename.py
+++ b/tests/whitebox/integration/logical/test_rename.py
@@ -20,7 +20,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import StratisCliActionError, StratisCliNoChangeError
+from stratis_cli._errors import StratisCliNoChangeError
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
@@ -62,9 +62,7 @@ class RenameTestCase(SimTestCase):
         Renaming the filesystem must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        check_error(
-            self, StratisCliActionError, StratisCliNoChangeError, command_line, ERROR
-        )
+        check_error(self, StratisCliNoChangeError, command_line, ERROR)
 
 
 class Rename1TestCase(SimTestCase):
@@ -83,26 +81,14 @@ class Rename1TestCase(SimTestCase):
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
 
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, ERROR)
 
     def testNonExistentPoolSameName(self):
         """
         Renaming the filesystem must fail, because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, ERROR)
 
 
 class Rename2TestCase(SimTestCase):
@@ -128,23 +114,11 @@ class Rename2TestCase(SimTestCase):
         Renaming the filesystem must fail, because filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, ERROR)
 
     def testNonExistentFilesystemSameName(self):
         """
         Renaming the filesystem must fail, because the filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, ERROR)

--- a/tests/whitebox/integration/logical/test_rename.py
+++ b/tests/whitebox/integration/logical/test_rename.py
@@ -19,11 +19,13 @@ Test 'rename'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError, StratisCliNoChangeError
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+ERROR = StratisCliErrorCodes.ERROR
 
 
 class RenameTestCase(SimTestCase):
@@ -60,10 +62,9 @@ class RenameTestCase(SimTestCase):
         Renaming the filesystem must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNoChangeError)
+        check_error(
+            self, StratisCliActionError, StratisCliNoChangeError, command_line, ERROR
+        )
 
 
 class Rename1TestCase(SimTestCase):
@@ -81,20 +82,27 @@ class Rename1TestCase(SimTestCase):
         Renaming the filesystem must fail, because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )
 
     def testNonExistentPoolSameName(self):
         """
         Renaming the filesystem must fail, because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )
 
 
 class Rename2TestCase(SimTestCase):
@@ -120,17 +128,23 @@ class Rename2TestCase(SimTestCase):
         Renaming the filesystem must fail, because filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )
 
     def testNonExistentFilesystemSameName(self):
         """
         Renaming the filesystem must fail, because the filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )

--- a/tests/whitebox/integration/logical/test_rename.py
+++ b/tests/whitebox/integration/logical/test_rename.py
@@ -22,7 +22,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliNoChangeError
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _ERROR = StratisCliErrorCodes.ERROR
@@ -62,7 +62,7 @@ class RenameTestCase(SimTestCase):
         Renaming the filesystem must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        check_error(self, StratisCliNoChangeError, command_line, _ERROR)
+        self.check_error(StratisCliNoChangeError, command_line, _ERROR)
 
 
 class Rename1TestCase(SimTestCase):
@@ -81,14 +81,14 @@ class Rename1TestCase(SimTestCase):
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
 
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
     def testNonExistentPoolSameName(self):
         """
         Renaming the filesystem must fail, because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Rename2TestCase(SimTestCase):
@@ -114,11 +114,11 @@ class Rename2TestCase(SimTestCase):
         Renaming the filesystem must fail, because filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
     def testNonExistentFilesystemSameName(self):
         """
         Renaming the filesystem must fail, because the filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_snapshot.py
+++ b/tests/whitebox/integration/logical/test_snapshot.py
@@ -20,12 +20,12 @@ from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import StratisCliActionError, StratisCliNoChangeError
+from stratis_cli._errors import StratisCliNoChangeError
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
-ERROR = StratisCliErrorCodes.ERROR
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class SnapshotTestCase(SimTestCase):
@@ -60,9 +60,7 @@ class SnapshotTestCase(SimTestCase):
         Creation of the snapshot must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        check_error(
-            self, StratisCliActionError, StratisCliNoChangeError, command_line, ERROR
-        )
+        check_error(self, StratisCliNoChangeError, command_line, _ERROR)
 
 
 class Snapshot1TestCase(SimTestCase):
@@ -80,13 +78,7 @@ class Snapshot1TestCase(SimTestCase):
         Creation of the snapshot must fail since specified pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Snapshot2TestCase(SimTestCase):
@@ -112,10 +104,4 @@ class Snapshot2TestCase(SimTestCase):
         Creation of the snapshot must fail since filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_snapshot.py
+++ b/tests/whitebox/integration/logical/test_snapshot.py
@@ -19,11 +19,13 @@ Test 'snapshot'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError, StratisCliNoChangeError
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+ERROR = StratisCliErrorCodes.ERROR
 
 
 class SnapshotTestCase(SimTestCase):
@@ -58,10 +60,9 @@ class SnapshotTestCase(SimTestCase):
         Creation of the snapshot must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNoChangeError)
+        check_error(
+            self, StratisCliActionError, StratisCliNoChangeError, command_line, ERROR
+        )
 
 
 class Snapshot1TestCase(SimTestCase):
@@ -79,10 +80,13 @@ class Snapshot1TestCase(SimTestCase):
         Creation of the snapshot must fail since specified pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )
 
 
 class Snapshot2TestCase(SimTestCase):
@@ -108,7 +112,10 @@ class Snapshot2TestCase(SimTestCase):
         Creation of the snapshot must fail since filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )

--- a/tests/whitebox/integration/logical/test_snapshot.py
+++ b/tests/whitebox/integration/logical/test_snapshot.py
@@ -22,7 +22,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliNoChangeError
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _ERROR = StratisCliErrorCodes.ERROR
@@ -60,7 +60,7 @@ class SnapshotTestCase(SimTestCase):
         Creation of the snapshot must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        check_error(self, StratisCliNoChangeError, command_line, _ERROR)
+        self.check_error(StratisCliNoChangeError, command_line, _ERROR)
 
 
 class Snapshot1TestCase(SimTestCase):
@@ -78,7 +78,7 @@ class Snapshot1TestCase(SimTestCase):
         Creation of the snapshot must fail since specified pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Snapshot2TestCase(SimTestCase):
@@ -104,4 +104,4 @@ class Snapshot2TestCase(SimTestCase):
         Creation of the snapshot must fail since filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/physical/test_list.py
+++ b/tests/whitebox/integration/physical/test_list.py
@@ -21,7 +21,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 
@@ -39,8 +39,8 @@ class ListTestCase(SimTestCase):
         Listing the devices must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME]
-        check_error(
-            self, DbusClientUniqueResultError, command_line, StratisCliErrorCodes.ERROR
+        self.check_error(
+            DbusClientUniqueResultError, command_line, StratisCliErrorCodes.ERROR
         )
 
     def testListEmpty(self):

--- a/tests/whitebox/integration/physical/test_list.py
+++ b/tests/whitebox/integration/physical/test_list.py
@@ -20,7 +20,6 @@ from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import StratisCliActionError
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
@@ -41,11 +40,7 @@ class ListTestCase(SimTestCase):
         """
         command_line = self._MENU + [self._POOLNAME]
         check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            StratisCliErrorCodes.ERROR,
+            self, DbusClientUniqueResultError, command_line, StratisCliErrorCodes.ERROR
         )
 
     def testListEmpty(self):

--- a/tests/whitebox/integration/physical/test_list.py
+++ b/tests/whitebox/integration/physical/test_list.py
@@ -19,9 +19,10 @@ Test 'list'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 
@@ -39,10 +40,13 @@ class ListTestCase(SimTestCase):
         Listing the devices must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            StratisCliErrorCodes.ERROR,
+        )
 
     def testListEmpty(self):
         """

--- a/tests/whitebox/integration/pool/test_add.py
+++ b/tests/whitebox/integration/pool/test_add.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test 'create'.
+Test 'add'.
 """
 
 # isort: FIRSTPARTY
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import (
     StratisCliActionError,
     StratisCliInUseOtherTierError,
@@ -26,10 +27,11 @@ from stratis_cli._errors import (
     StratisCliPartialChangeError,
 )
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1, 1)
 _DEVICE_STRATEGY_2 = device_name_list(2, 2)
+ERROR = StratisCliErrorCodes.ERROR
 
 
 class AddDataTestCase(SimTestCase):
@@ -45,10 +47,13 @@ class AddDataTestCase(SimTestCase):
         Adding the devices must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )
 
 
 class AddCacheTestCase(SimTestCase):
@@ -63,11 +68,15 @@ class AddCacheTestCase(SimTestCase):
         """
         Adding the devices must fail since the pool does not exist.
         """
+
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            ERROR,
+        )
 
 
 class AddDataTestCase1(SimTestCase):
@@ -99,10 +108,13 @@ class AddDataTestCase1(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )
 
     def testAddDataCache(self):
         """
@@ -112,11 +124,13 @@ class AddDataTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY()
         command_line = ["--propagate", "pool", "add-cache"] + [self._POOLNAME] + devices
         RUNNER(command_line)
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(self._MENU + [self._POOLNAME] + devices)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseOtherTierError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliInUseOtherTierError,
+            self._MENU + [self._POOLNAME] + devices,
+            ERROR,
+        )
 
     def testAddDataCache2(self):
         """
@@ -126,11 +140,13 @@ class AddDataTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY_2()
         command_line = ["--propagate", "pool", "add-cache"] + [self._POOLNAME] + devices
         RUNNER(command_line)
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(self._MENU + [self._POOLNAME] + devices)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseOtherTierError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliInUseOtherTierError,
+            self._MENU + [self._POOLNAME] + devices,
+            ERROR,
+        )
 
 
 class AddDataTestCase2(SimTestCase):
@@ -157,11 +173,13 @@ class AddDataTestCase2(SimTestCase):
         Test that adding the same devices to the data tier in a different pool fails.
         """
         command_line = self._MENU + [self._POOLNAME] + self._SECOND_DEVICES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseSameTierError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliInUseSameTierError,
+            command_line,
+            ERROR,
+        )
 
 
 class AddCacheTestCase1(SimTestCase):
@@ -195,11 +213,13 @@ class AddCacheTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY()
         command_line = self._MENU + [self._POOLNAME] + devices
         RUNNER(command_line)
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliPartialChangeError,
+            command_line,
+            ERROR,
+        )
 
     def testAddCacheData(self):
         """
@@ -207,11 +227,13 @@ class AddCacheTestCase1(SimTestCase):
         an exception.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseOtherTierError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliInUseOtherTierError,
+            command_line,
+            ERROR,
+        )
 
 
 class AddCacheTestCase2(SimTestCase):
@@ -234,8 +256,10 @@ class AddCacheTestCase2(SimTestCase):
         an exception.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES_2
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseOtherTierError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliInUseOtherTierError,
+            command_line,
+            ERROR,
+        )

--- a/tests/whitebox/integration/pool/test_add.py
+++ b/tests/whitebox/integration/pool/test_add.py
@@ -21,7 +21,6 @@ from dbus_client_gen import DbusClientUniqueResultError
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import (
-    StratisCliActionError,
     StratisCliInUseOtherTierError,
     StratisCliInUseSameTierError,
     StratisCliPartialChangeError,
@@ -31,7 +30,7 @@ from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1, 1)
 _DEVICE_STRATEGY_2 = device_name_list(2, 2)
-ERROR = StratisCliErrorCodes.ERROR
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class AddDataTestCase(SimTestCase):
@@ -47,13 +46,7 @@ class AddDataTestCase(SimTestCase):
         Adding the devices must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class AddCacheTestCase(SimTestCase):
@@ -70,13 +63,7 @@ class AddCacheTestCase(SimTestCase):
         """
 
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class AddDataTestCase1(SimTestCase):
@@ -108,13 +95,7 @@ class AddDataTestCase1(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
 
     def testAddDataCache(self):
         """
@@ -126,10 +107,9 @@ class AddDataTestCase1(SimTestCase):
         RUNNER(command_line)
         check_error(
             self,
-            StratisCliActionError,
             StratisCliInUseOtherTierError,
             self._MENU + [self._POOLNAME] + devices,
-            ERROR,
+            _ERROR,
         )
 
     def testAddDataCache2(self):
@@ -142,10 +122,9 @@ class AddDataTestCase1(SimTestCase):
         RUNNER(command_line)
         check_error(
             self,
-            StratisCliActionError,
             StratisCliInUseOtherTierError,
             self._MENU + [self._POOLNAME] + devices,
-            ERROR,
+            _ERROR,
         )
 
 
@@ -173,13 +152,7 @@ class AddDataTestCase2(SimTestCase):
         Test that adding the same devices to the data tier in a different pool fails.
         """
         command_line = self._MENU + [self._POOLNAME] + self._SECOND_DEVICES
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliInUseSameTierError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliInUseSameTierError, command_line, _ERROR)
 
 
 class AddCacheTestCase1(SimTestCase):
@@ -213,13 +186,7 @@ class AddCacheTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY()
         command_line = self._MENU + [self._POOLNAME] + devices
         RUNNER(command_line)
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliPartialChangeError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
 
     def testAddCacheData(self):
         """
@@ -227,13 +194,7 @@ class AddCacheTestCase1(SimTestCase):
         an exception.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliInUseOtherTierError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliInUseOtherTierError, command_line, _ERROR)
 
 
 class AddCacheTestCase2(SimTestCase):
@@ -256,10 +217,4 @@ class AddCacheTestCase2(SimTestCase):
         an exception.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES_2
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliInUseOtherTierError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliInUseOtherTierError, command_line, _ERROR)

--- a/tests/whitebox/integration/pool/test_add.py
+++ b/tests/whitebox/integration/pool/test_add.py
@@ -26,7 +26,7 @@ from stratis_cli._errors import (
     StratisCliPartialChangeError,
 )
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1, 1)
 _DEVICE_STRATEGY_2 = device_name_list(2, 2)
@@ -46,7 +46,7 @@ class AddDataTestCase(SimTestCase):
         Adding the devices must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class AddCacheTestCase(SimTestCase):
@@ -63,7 +63,7 @@ class AddCacheTestCase(SimTestCase):
         """
 
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class AddDataTestCase1(SimTestCase):
@@ -95,7 +95,7 @@ class AddDataTestCase1(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def testAddDataCache(self):
         """
@@ -105,8 +105,7 @@ class AddDataTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY()
         command_line = ["--propagate", "pool", "add-cache"] + [self._POOLNAME] + devices
         RUNNER(command_line)
-        check_error(
-            self,
+        self.check_error(
             StratisCliInUseOtherTierError,
             self._MENU + [self._POOLNAME] + devices,
             _ERROR,
@@ -120,8 +119,7 @@ class AddDataTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY_2()
         command_line = ["--propagate", "pool", "add-cache"] + [self._POOLNAME] + devices
         RUNNER(command_line)
-        check_error(
-            self,
+        self.check_error(
             StratisCliInUseOtherTierError,
             self._MENU + [self._POOLNAME] + devices,
             _ERROR,
@@ -152,7 +150,7 @@ class AddDataTestCase2(SimTestCase):
         Test that adding the same devices to the data tier in a different pool fails.
         """
         command_line = self._MENU + [self._POOLNAME] + self._SECOND_DEVICES
-        check_error(self, StratisCliInUseSameTierError, command_line, _ERROR)
+        self.check_error(StratisCliInUseSameTierError, command_line, _ERROR)
 
 
 class AddCacheTestCase1(SimTestCase):
@@ -186,7 +184,7 @@ class AddCacheTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY()
         command_line = self._MENU + [self._POOLNAME] + devices
         RUNNER(command_line)
-        check_error(self, StratisCliPartialChangeError, command_line, _ERROR)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def testAddCacheData(self):
         """
@@ -194,7 +192,7 @@ class AddCacheTestCase1(SimTestCase):
         an exception.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        check_error(self, StratisCliInUseOtherTierError, command_line, _ERROR)
+        self.check_error(StratisCliInUseOtherTierError, command_line, _ERROR)
 
 
 class AddCacheTestCase2(SimTestCase):
@@ -217,4 +215,4 @@ class AddCacheTestCase2(SimTestCase):
         an exception.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES_2
-        check_error(self, StratisCliInUseOtherTierError, command_line, _ERROR)
+        self.check_error(StratisCliInUseOtherTierError, command_line, _ERROR)

--- a/tests/whitebox/integration/pool/test_create.py
+++ b/tests/whitebox/integration/pool/test_create.py
@@ -16,16 +16,18 @@ Test 'create'.
 """
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import (
     StratisCliActionError,
     StratisCliInUseSameTierError,
     StratisCliNameConflictError,
 )
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _DEVICE_STRATEGY_2 = device_name_list(2)
+ERROR = StratisCliErrorCodes.ERROR
 
 
 class Create3TestCase(SimTestCase):
@@ -51,11 +53,13 @@ class Create3TestCase(SimTestCase):
         new pool with the same devices and the same name as previous.
         """
         command_line = self._MENU + [self._POOLNAME] + self.devices
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNameConflictError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliNameConflictError,
+            command_line,
+            ERROR,
+        )
 
     def testCreateDifferentDevices(self):
         """
@@ -63,11 +67,13 @@ class Create3TestCase(SimTestCase):
         new pool with different devices and the same name as previous.
         """
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNameConflictError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliNameConflictError,
+            command_line,
+            ERROR,
+        )
 
 
 class Create4TestCase(SimTestCase):
@@ -91,8 +97,10 @@ class Create4TestCase(SimTestCase):
         a StratisCliInUseSameTierError exception.
         """
         command_line = self._MENU + [self._POOLNAME_2] + self._DEVICES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseSameTierError)
-        self.assertNotEqual(str(cause), "")
+        check_error(
+            self,
+            StratisCliActionError,
+            StratisCliInUseSameTierError,
+            command_line,
+            ERROR,
+        )

--- a/tests/whitebox/integration/pool/test_create.py
+++ b/tests/whitebox/integration/pool/test_create.py
@@ -18,7 +18,6 @@ Test 'create'.
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import (
-    StratisCliActionError,
     StratisCliInUseSameTierError,
     StratisCliNameConflictError,
 )
@@ -27,7 +26,7 @@ from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _DEVICE_STRATEGY_2 = device_name_list(2)
-ERROR = StratisCliErrorCodes.ERROR
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class Create3TestCase(SimTestCase):
@@ -53,13 +52,7 @@ class Create3TestCase(SimTestCase):
         new pool with the same devices and the same name as previous.
         """
         command_line = self._MENU + [self._POOLNAME] + self.devices
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliNameConflictError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliNameConflictError, command_line, _ERROR)
 
     def testCreateDifferentDevices(self):
         """
@@ -67,13 +60,7 @@ class Create3TestCase(SimTestCase):
         new pool with different devices and the same name as previous.
         """
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliNameConflictError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliNameConflictError, command_line, _ERROR)
 
 
 class Create4TestCase(SimTestCase):
@@ -97,10 +84,4 @@ class Create4TestCase(SimTestCase):
         a StratisCliInUseSameTierError exception.
         """
         command_line = self._MENU + [self._POOLNAME_2] + self._DEVICES
-        check_error(
-            self,
-            StratisCliActionError,
-            StratisCliInUseSameTierError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, StratisCliInUseSameTierError, command_line, _ERROR)

--- a/tests/whitebox/integration/pool/test_create.py
+++ b/tests/whitebox/integration/pool/test_create.py
@@ -22,7 +22,7 @@ from stratis_cli._errors import (
     StratisCliNameConflictError,
 )
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _DEVICE_STRATEGY_2 = device_name_list(2)
@@ -52,7 +52,7 @@ class Create3TestCase(SimTestCase):
         new pool with the same devices and the same name as previous.
         """
         command_line = self._MENU + [self._POOLNAME] + self.devices
-        check_error(self, StratisCliNameConflictError, command_line, _ERROR)
+        self.check_error(StratisCliNameConflictError, command_line, _ERROR)
 
     def testCreateDifferentDevices(self):
         """
@@ -60,7 +60,7 @@ class Create3TestCase(SimTestCase):
         new pool with different devices and the same name as previous.
         """
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        check_error(self, StratisCliNameConflictError, command_line, _ERROR)
+        self.check_error(StratisCliNameConflictError, command_line, _ERROR)
 
 
 class Create4TestCase(SimTestCase):
@@ -84,4 +84,4 @@ class Create4TestCase(SimTestCase):
         a StratisCliInUseSameTierError exception.
         """
         command_line = self._MENU + [self._POOLNAME_2] + self._DEVICES
-        check_error(self, StratisCliInUseSameTierError, command_line, _ERROR)
+        self.check_error(StratisCliInUseSameTierError, command_line, _ERROR)

--- a/tests/whitebox/integration/pool/test_destroy.py
+++ b/tests/whitebox/integration/pool/test_destroy.py
@@ -20,12 +20,12 @@ from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import StratisCliActionError, StratisCliEngineError
+from stratis_cli._errors import StratisCliEngineError
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
-ERROR = StratisCliErrorCodes.ERROR
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class Destroy1TestCase(SimTestCase):
@@ -43,13 +43,7 @@ class Destroy1TestCase(SimTestCase):
         Destroy should fail because there is no object path for the pool.
         """
         command_line = self._MENU + [self._POOLNAME]
-        check_error(
-            self,
-            StratisCliActionError,
-            DbusClientUniqueResultError,
-            command_line,
-            ERROR,
-        )
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Destroy2TestCase(SimTestCase):
@@ -101,9 +95,7 @@ class Destroy3TestCase(SimTestCase):
         This should fail since it has a filesystem.
         """
         command_line = self._MENU + [self._POOLNAME]
-        check_error(
-            self, StratisCliActionError, StratisCliEngineError, command_line, ERROR
-        )
+        check_error(self, StratisCliEngineError, command_line, _ERROR)
 
     def testWithFilesystemRemoved(self):
         """

--- a/tests/whitebox/integration/pool/test_destroy.py
+++ b/tests/whitebox/integration/pool/test_destroy.py
@@ -21,11 +21,11 @@ from dbus_client_gen import DbusClientUniqueResultError
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError, StratisCliEngineError
-from stratis_cli._stratisd_constants import StratisdErrors
 
 from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+ERROR = StratisCliErrorCodes.ERROR
 
 
 class Destroy1TestCase(SimTestCase):
@@ -48,7 +48,7 @@ class Destroy1TestCase(SimTestCase):
             StratisCliActionError,
             DbusClientUniqueResultError,
             command_line,
-            StratisCliErrorCodes.ERROR,
+            ERROR,
         )
 
 
@@ -101,11 +101,9 @@ class Destroy3TestCase(SimTestCase):
         This should fail since it has a filesystem.
         """
         command_line = self._MENU + [self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliEngineError)
-        self.assertEqual(cause.rc, StratisdErrors.BUSY)
+        check_error(
+            self, StratisCliActionError, StratisCliEngineError, command_line, ERROR
+        )
 
     def testWithFilesystemRemoved(self):
         """

--- a/tests/whitebox/integration/pool/test_destroy.py
+++ b/tests/whitebox/integration/pool/test_destroy.py
@@ -19,10 +19,11 @@ Test 'destroy'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError, StratisCliEngineError
 from stratis_cli._stratisd_constants import StratisdErrors
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 
@@ -42,10 +43,13 @@ class Destroy1TestCase(SimTestCase):
         Destroy should fail because there is no object path for the pool.
         """
         command_line = self._MENU + [self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(
+            self,
+            StratisCliActionError,
+            DbusClientUniqueResultError,
+            command_line,
+            StratisCliErrorCodes.ERROR,
+        )
 
 
 class Destroy2TestCase(SimTestCase):

--- a/tests/whitebox/integration/pool/test_destroy.py
+++ b/tests/whitebox/integration/pool/test_destroy.py
@@ -22,7 +22,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliEngineError
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _ERROR = StratisCliErrorCodes.ERROR
@@ -43,7 +43,7 @@ class Destroy1TestCase(SimTestCase):
         Destroy should fail because there is no object path for the pool.
         """
         command_line = self._MENU + [self._POOLNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Destroy2TestCase(SimTestCase):
@@ -95,7 +95,7 @@ class Destroy3TestCase(SimTestCase):
         This should fail since it has a filesystem.
         """
         command_line = self._MENU + [self._POOLNAME]
-        check_error(self, StratisCliEngineError, command_line, _ERROR)
+        self.check_error(StratisCliEngineError, command_line, _ERROR)
 
     def testWithFilesystemRemoved(self):
         """

--- a/tests/whitebox/integration/pool/test_rename.py
+++ b/tests/whitebox/integration/pool/test_rename.py
@@ -19,11 +19,13 @@ Test 'rename'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import StratisCliActionError, StratisCliNoChangeError
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._errors import StratisCliNoChangeError
 
-from .._misc import RUNNER, SimTestCase, device_name_list
+from .._misc import RUNNER, SimTestCase, check_error, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class Rename1TestCase(SimTestCase):
@@ -40,20 +42,14 @@ class Rename1TestCase(SimTestCase):
         This should fail because original name does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._NEW_POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
     def testSameName(self):
         """
         Renaming to itself will fail because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Rename2TestCase(SimTestCase):
@@ -85,17 +81,11 @@ class Rename2TestCase(SimTestCase):
         This should fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNoChangeError)
+        check_error(self, StratisCliNoChangeError, command_line, _ERROR)
 
     def testNonExistentPool(self):
         """
         This should fail, because this pool is not there.
         """
         command_line = self._MENU + ["nopool", self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/pool/test_rename.py
+++ b/tests/whitebox/integration/pool/test_rename.py
@@ -22,7 +22,7 @@ from dbus_client_gen import DbusClientUniqueResultError
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliNoChangeError
 
-from .._misc import RUNNER, SimTestCase, check_error, device_name_list
+from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _ERROR = StratisCliErrorCodes.ERROR
@@ -42,14 +42,14 @@ class Rename1TestCase(SimTestCase):
         This should fail because original name does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._NEW_POOLNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
     def testSameName(self):
         """
         Renaming to itself will fail because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._POOLNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Rename2TestCase(SimTestCase):
@@ -81,11 +81,11 @@ class Rename2TestCase(SimTestCase):
         This should fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._POOLNAME]
-        check_error(self, StratisCliNoChangeError, command_line, _ERROR)
+        self.check_error(StratisCliNoChangeError, command_line, _ERROR)
 
     def testNonExistentPool(self):
         """
         This should fail, because this pool is not there.
         """
         command_line = self._MENU + ["nopool", self._POOLNAME]
-        check_error(self, DbusClientUniqueResultError, command_line, _ERROR)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -26,14 +26,18 @@ from ._misc import RUNNER, SimTestCase
 PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
 
-def check_parse_error(obj, command_line_args, expected_code):
+def check_parse_error(obj, command_line, expected_code):
     """
     Check that running the program with given prefix and command line arguments
     will return an exit code which matches the expected code, in this case a
     parser error.
+    
+    :param command_line: the arguments given to command line
+    :param expected_code: the expected exit code from running with these arguments
+    :type expected_code: IntEnum
     """
     with obj.assertRaises(SystemExit) as context:
-        RUNNER(command_line_args)
+        RUNNER(command_line)
     exit_code = context.exception.code
     obj.assertEqual(exit_code, expected_code)
 

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -23,6 +23,8 @@ from stratis_cli._error_reporting import StratisCliErrorCodes
 
 from ._misc import RUNNER, SimTestCase
 
+PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
+
 
 class ParserTestCase(unittest.TestCase):
     """
@@ -44,7 +46,7 @@ class ParserTestCase(unittest.TestCase):
                 with self.assertRaises(SystemExit) as context:
                     RUNNER(prefix + command_line)
                 exit_code = context.exception.code
-                self.assertEqual(exit_code, 2)
+                self.assertEqual(exit_code, PARSE_ERROR)
 
     def testStratisTwoOptions(self):
         """
@@ -56,7 +58,7 @@ class ParserTestCase(unittest.TestCase):
             with self.assertRaises(SystemExit) as context:
                 RUNNER(prefix + command_line)
             exit_code = context.exception.code
-            self.assertEqual(exit_code, 2)
+            self.assertEqual(exit_code, PARSE_ERROR)
 
     def testStratisBadSubcommand(self):
         """
@@ -74,7 +76,7 @@ class ParserTestCase(unittest.TestCase):
                 with self.assertRaises(SystemExit) as context:
                     RUNNER(prefix + command_line)
                 exit_code = context.exception.code
-                self.assertEqual(exit_code, 2)
+                self.assertEqual(exit_code, PARSE_ERROR)
 
     def testRedundancy(self):
         """
@@ -95,7 +97,7 @@ class ParserTestCase(unittest.TestCase):
             with self.assertRaises(SystemExit) as context:
                 RUNNER(prefix + command_line)
             exit_code = context.exception.code
-            self.assertEqual(exit_code, 2)
+            self.assertEqual(exit_code, PARSE_ERROR)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -25,7 +25,8 @@ from ._misc import RUNNER, SimTestCase
 
 PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
-def check_error_raised(obj, command_line_args, expected_code):
+
+def check_parse_error(obj, command_line_args, expected_code):
     """
     Check that running the program with given prefix and command line arguments
     will return an exit code which matches the expected code, in this case a
@@ -54,7 +55,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                check_error_raised(self, prefix + command_line, PARSE_ERROR)
+                check_parse_error(self, prefix + command_line, PARSE_ERROR)
 
     def testStratisTwoOptions(self):
         """
@@ -63,7 +64,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            check_error_raised(self, prefix + command_line, PARSE_ERROR)
+            check_parse_error(self, prefix + command_line, PARSE_ERROR)
 
     def testStratisBadSubcommand(self):
         """
@@ -78,7 +79,7 @@ class ParserTestCase(unittest.TestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                check_error_raised(self, prefix + command_line, PARSE_ERROR)
+                check_parse_error(self, prefix + command_line, PARSE_ERROR)
 
     def testRedundancy(self):
         """
@@ -96,7 +97,7 @@ class ParserTestCase(unittest.TestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            check_error_raised(self, prefix + command_line, PARSE_ERROR)
+            check_parse_error(self, prefix + command_line, PARSE_ERROR)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -23,7 +23,7 @@ from stratis_cli._error_reporting import StratisCliErrorCodes
 
 from ._misc import RUNNER, SimTestCase
 
-PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
+_PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
 
 def check_parse_error(obj, command_line, expected_code):
@@ -59,7 +59,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                check_parse_error(self, prefix + command_line, PARSE_ERROR)
+                check_parse_error(self, prefix + command_line, _PARSE_ERROR)
 
     def testStratisTwoOptions(self):
         """
@@ -68,7 +68,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            check_parse_error(self, prefix + command_line, PARSE_ERROR)
+            check_parse_error(self, prefix + command_line, _PARSE_ERROR)
 
     def testStratisBadSubcommand(self):
         """
@@ -83,7 +83,7 @@ class ParserTestCase(unittest.TestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                check_parse_error(self, prefix + command_line, PARSE_ERROR)
+                check_parse_error(self, prefix + command_line, _PARSE_ERROR)
 
     def testRedundancy(self):
         """
@@ -101,7 +101,7 @@ class ParserTestCase(unittest.TestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            check_parse_error(self, prefix + command_line, PARSE_ERROR)
+            check_parse_error(self, prefix + command_line, _PARSE_ERROR)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -26,14 +26,14 @@ from ._misc import RUNNER, SimTestCase
 PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
 
-def checkErrorRaised(obj, command_line, prefix, expected_code):
+def check_error_raised(obj, command_line_args, expected_code):
     """
     Check that running the program with given prefix and command line arguments
     will return an exit code which matches the expected code, in this case a
     parser error.
     """
     with obj.assertRaises(SystemExit) as context:
-        RUNNER(prefix + command_line)
+        RUNNER(command_line_args)
     exit_code = context.exception.code
     obj.assertEqual(exit_code, expected_code)
 
@@ -55,7 +55,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                checkErrorRaised(self, command_line, prefix, PARSE_ERROR)
+                check_error_raised(self, prefix + command_line, PARSE_ERROR)
 
     def testStratisTwoOptions(self):
         """
@@ -64,7 +64,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            checkErrorRaised(self, command_line, prefix, PARSE_ERROR)
+            check_error_raised(self, prefix + command_line, PARSE_ERROR)
 
     def testStratisBadSubcommand(self):
         """
@@ -79,7 +79,7 @@ class ParserTestCase(unittest.TestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                checkErrorRaised(self, command_line, prefix, PARSE_ERROR)
+                check_error_raised(self, prefix + command_line, PARSE_ERROR)
 
     def testRedundancy(self):
         """
@@ -97,7 +97,7 @@ class ParserTestCase(unittest.TestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            checkErrorRaised(self, command_line, prefix, PARSE_ERROR)
+            check_error_raised(self, prefix + command_line, PARSE_ERROR)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -26,6 +26,18 @@ from ._misc import RUNNER, SimTestCase
 PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
 
+def checkErrorRaised(obj, command_line, prefix, expected_code):
+    """
+    Check that running the program with given prefix and command line arguments
+    will return an exit code which matches the expected code, in this case a
+    parser error.
+    """
+    with obj.assertRaises(SystemExit) as context:
+        RUNNER(prefix + command_line)
+    exit_code = context.exception.code
+    obj.assertEqual(exit_code, expected_code)
+
+
 class ParserTestCase(unittest.TestCase):
     """
     Test parser behavior. The behavior should be identical, regardless of
@@ -43,10 +55,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                with self.assertRaises(SystemExit) as context:
-                    RUNNER(prefix + command_line)
-                exit_code = context.exception.code
-                self.assertEqual(exit_code, PARSE_ERROR)
+                checkErrorRaised(self, command_line, prefix, PARSE_ERROR)
 
     def testStratisTwoOptions(self):
         """
@@ -55,10 +64,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            with self.assertRaises(SystemExit) as context:
-                RUNNER(prefix + command_line)
-            exit_code = context.exception.code
-            self.assertEqual(exit_code, PARSE_ERROR)
+            checkErrorRaised(self, command_line, prefix, PARSE_ERROR)
 
     def testStratisBadSubcommand(self):
         """
@@ -73,10 +79,7 @@ class ParserTestCase(unittest.TestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                with self.assertRaises(SystemExit) as context:
-                    RUNNER(prefix + command_line)
-                exit_code = context.exception.code
-                self.assertEqual(exit_code, PARSE_ERROR)
+                checkErrorRaised(self, command_line, prefix, PARSE_ERROR)
 
     def testRedundancy(self):
         """
@@ -94,10 +97,7 @@ class ParserTestCase(unittest.TestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            with self.assertRaises(SystemExit) as context:
-                RUNNER(prefix + command_line)
-            exit_code = context.exception.code
-            self.assertEqual(exit_code, PARSE_ERROR)
+            checkErrorRaised(self, command_line, prefix, PARSE_ERROR)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -15,34 +15,10 @@
 Test command-line argument parsing.
 """
 
-# isort: STDLIB
-import unittest
-
-# isort: LOCAL
-from stratis_cli._error_reporting import StratisCliErrorCodes
-
-from ._misc import RUNNER, SimTestCase
-
-_PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
+from ._misc import RUNNER, RunTestCase, SimTestCase
 
 
-def check_parse_error(obj, command_line):
-    """
-    Check that running the program with given prefix and command line arguments
-    will return an exit code which matches the expected code, in this case a
-    parser error.
-    :param obj: the instance of a unit test
-    :type obj: unittest.TestCase
-    :param command_line: the command line arguments
-    :type command_line: list
-    """
-    with obj.assertRaises(SystemExit) as context:
-        RUNNER(command_line)
-    exit_code = context.exception.code
-    obj.assertEqual(exit_code, _PARSE_ERROR)
-
-
-class ParserTestCase(unittest.TestCase):
+class ParserTestCase(RunTestCase):
     """
     Test parser behavior. The behavior should be identical, regardless of
     whether the "--propagate" flag is set. That is, stratis should never produce
@@ -59,7 +35,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                check_parse_error(self, prefix + command_line)
+                self.check_parse_error(prefix + command_line)
 
     def testStratisTwoOptions(self):
         """
@@ -68,7 +44,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            check_parse_error(self, prefix + command_line)
+            self.check_parse_error(prefix + command_line)
 
     def testStratisBadSubcommand(self):
         """
@@ -83,7 +59,7 @@ class ParserTestCase(unittest.TestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                check_parse_error(self, prefix + command_line)
+                self.check_parse_error(prefix + command_line)
 
     def testRedundancy(self):
         """
@@ -101,7 +77,7 @@ class ParserTestCase(unittest.TestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            check_parse_error(self, prefix + command_line)
+            self.check_parse_error(prefix + command_line)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -26,20 +26,20 @@ from ._misc import RUNNER, SimTestCase
 _PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
 
-def check_parse_error(obj, command_line, expected_code):
+def check_parse_error(obj, command_line):
     """
     Check that running the program with given prefix and command line arguments
     will return an exit code which matches the expected code, in this case a
     parser error.
-
+    :param obj: the instance of a unit test
+    :type obj: unittest.TestCase
     :param command_line: the command line arguments
-    :param expected_code: the expected exit code
-    :type expected_code: int
+    :type command_line: list
     """
     with obj.assertRaises(SystemExit) as context:
         RUNNER(command_line)
     exit_code = context.exception.code
-    obj.assertEqual(exit_code, expected_code)
+    obj.assertEqual(exit_code, _PARSE_ERROR)
 
 
 class ParserTestCase(unittest.TestCase):
@@ -59,7 +59,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                check_parse_error(self, prefix + command_line, _PARSE_ERROR)
+                check_parse_error(self, prefix + command_line)
 
     def testStratisTwoOptions(self):
         """
@@ -68,7 +68,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            check_parse_error(self, prefix + command_line, _PARSE_ERROR)
+            check_parse_error(self, prefix + command_line)
 
     def testStratisBadSubcommand(self):
         """
@@ -83,7 +83,7 @@ class ParserTestCase(unittest.TestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                check_parse_error(self, prefix + command_line, _PARSE_ERROR)
+                check_parse_error(self, prefix + command_line)
 
     def testRedundancy(self):
         """
@@ -101,7 +101,7 @@ class ParserTestCase(unittest.TestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            check_parse_error(self, prefix + command_line, _PARSE_ERROR)
+            check_parse_error(self, prefix + command_line)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -31,7 +31,7 @@ def check_parse_error(obj, command_line, expected_code):
     Check that running the program with given prefix and command line arguments
     will return an exit code which matches the expected code, in this case a
     parser error.
-    
+
     :param command_line: the arguments given to command line
     :param expected_code: the expected exit code from running with these arguments
     :type expected_code: IntEnum

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -40,7 +40,7 @@ class ParserTestCase(RunTestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                self.check_parse_error(prefix + command_line, _PARSE_ERROR)
+                self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
     def testStratisTwoOptions(self):
         """
@@ -49,7 +49,7 @@ class ParserTestCase(RunTestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            self.check_parse_error(prefix + command_line, _PARSE_ERROR)
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
     def testStratisBadSubcommand(self):
         """
@@ -64,7 +64,7 @@ class ParserTestCase(RunTestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                self.check_parse_error(prefix + command_line, _PARSE_ERROR)
+                self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
     def testRedundancy(self):
         """
@@ -82,7 +82,7 @@ class ParserTestCase(RunTestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            self.check_parse_error(prefix + command_line, _PARSE_ERROR)
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -25,7 +25,6 @@ from ._misc import RUNNER, SimTestCase
 
 PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
-
 def check_error_raised(obj, command_line_args, expected_code):
     """
     Check that running the program with given prefix and command line arguments

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -18,6 +18,9 @@ Test command-line argument parsing.
 # isort: STDLIB
 import unittest
 
+# isort: LOCAL
+from stratis_cli._error_reporting import StratisCliErrorCodes
+
 from ._misc import RUNNER, SimTestCase
 
 

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -15,7 +15,12 @@
 Test command-line argument parsing.
 """
 
+# isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
+
 from ._misc import RUNNER, RunTestCase, SimTestCase
+
+_PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
 
 class ParserTestCase(RunTestCase):
@@ -35,7 +40,7 @@ class ParserTestCase(RunTestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                self.check_parse_error(prefix + command_line)
+                self.check_parse_error(prefix + command_line, _PARSE_ERROR)
 
     def testStratisTwoOptions(self):
         """
@@ -44,7 +49,7 @@ class ParserTestCase(RunTestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            self.check_parse_error(prefix + command_line)
+            self.check_parse_error(prefix + command_line, _PARSE_ERROR)
 
     def testStratisBadSubcommand(self):
         """
@@ -59,7 +64,7 @@ class ParserTestCase(RunTestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                self.check_parse_error(prefix + command_line)
+                self.check_parse_error(prefix + command_line, _PARSE_ERROR)
 
     def testRedundancy(self):
         """
@@ -77,7 +82,7 @@ class ParserTestCase(RunTestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            self.check_parse_error(prefix + command_line)
+            self.check_parse_error(prefix + command_line, _PARSE_ERROR)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -32,9 +32,9 @@ def check_parse_error(obj, command_line, expected_code):
     will return an exit code which matches the expected code, in this case a
     parser error.
 
-    :param command_line: the arguments given to command line
-    :param expected_code: the expected exit code from running with these arguments
-    :type expected_code: IntEnum
+    :param command_line: the command line arguments
+    :param expected_code: the expected exit code
+    :type expected_code: int
     """
     with obj.assertRaises(SystemExit) as context:
         RUNNER(command_line)

--- a/tests/whitebox/integration/test_stratis.py
+++ b/tests/whitebox/integration/test_stratis.py
@@ -22,9 +22,10 @@ import unittest
 import dbus
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError
 
-from ._misc import RUNNER, SimTestCase
+from ._misc import RUNNER, SimTestCase, check_error
 
 
 class StratisTestCase(SimTestCase):
@@ -59,10 +60,13 @@ class PropagateTestCase(unittest.TestCase):
         If propagate is set, the expected exception will propagate.
         """
         command_line = ["--propagate", "daemon", "version"]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, dbus.exceptions.DBusException)
+        check_error(
+            self,
+            StratisCliActionError,
+            dbus.exceptions.DBusException,
+            command_line,
+            StratisCliErrorCodes.ERROR,
+        )
 
     def testNotPropagate(self):
         """

--- a/tests/whitebox/integration/test_stratis.py
+++ b/tests/whitebox/integration/test_stratis.py
@@ -24,6 +24,8 @@ from stratis_cli._errors import StratisCliActionError
 
 from ._misc import RUNNER, RunTestCase, SimTestCase
 
+_ERROR = StratisCliErrorCodes.ERROR
+
 
 class StratisTestCase(SimTestCase):
     """
@@ -57,9 +59,7 @@ class PropagateTestCase(RunTestCase):
         If propagate is set, the expected exception will propagate.
         """
         command_line = ["--propagate", "daemon", "version"]
-        self.check_error(
-            dbus.exceptions.DBusException, command_line, StratisCliErrorCodes.ERROR
-        )
+        self.check_error(dbus.exceptions.DBusException, command_line, _ERROR)
 
     def testNotPropagate(self):
         """
@@ -89,8 +89,4 @@ class ErrorHandlingTestCase(SimTestCase):
         # If instead the exception chain is handed off to handle_error,
         # the exception is recognized, an error message is generated,
         # and the program exits with the message via SystemExit.
-        with self.assertRaises(SystemExit) as context:
-            RUNNER(command_line)
-        exit_code = context.exception.code
-        self.assertNotEqual(exit_code, 0)
-        self.assertIsNotNone(exit_code)
+        self.check_parse_error(command_line, _ERROR)

--- a/tests/whitebox/integration/test_stratis.py
+++ b/tests/whitebox/integration/test_stratis.py
@@ -62,7 +62,6 @@ class PropagateTestCase(unittest.TestCase):
         command_line = ["--propagate", "daemon", "version"]
         check_error(
             self,
-            StratisCliActionError,
             dbus.exceptions.DBusException,
             command_line,
             StratisCliErrorCodes.ERROR,

--- a/tests/whitebox/integration/test_stratis.py
+++ b/tests/whitebox/integration/test_stratis.py
@@ -15,9 +15,6 @@
 Test 'stratisd'.
 """
 
-# isort: STDLIB
-import unittest
-
 # isort: THIRDPARTY
 import dbus
 
@@ -25,7 +22,7 @@ import dbus
 from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError
 
-from ._misc import RUNNER, SimTestCase, check_error
+from ._misc import RUNNER, RunTestCase, SimTestCase
 
 
 class StratisTestCase(SimTestCase):
@@ -50,7 +47,7 @@ class StratisTestCase(SimTestCase):
         RUNNER(command_line)
 
 
-class PropagateTestCase(unittest.TestCase):
+class PropagateTestCase(RunTestCase):
     """
     Verify correct operation of --propagate flag.
     """
@@ -60,11 +57,8 @@ class PropagateTestCase(unittest.TestCase):
         If propagate is set, the expected exception will propagate.
         """
         command_line = ["--propagate", "daemon", "version"]
-        check_error(
-            self,
-            dbus.exceptions.DBusException,
-            command_line,
-            StratisCliErrorCodes.ERROR,
+        self.check_error(
+            dbus.exceptions.DBusException, command_line, StratisCliErrorCodes.ERROR
         )
 
     def testNotPropagate(self):

--- a/tests/whitebox/integration/test_stratis.py
+++ b/tests/whitebox/integration/test_stratis.py
@@ -89,4 +89,4 @@ class ErrorHandlingTestCase(SimTestCase):
         # If instead the exception chain is handed off to handle_error,
         # the exception is recognized, an error message is generated,
         # and the program exits with the message via SystemExit.
-        self.check_parse_error(command_line, _ERROR)
+        self.check_system_exit(command_line, _ERROR)

--- a/tests/whitebox/unittest/test_error_fmt.py
+++ b/tests/whitebox/unittest/test_error_fmt.py
@@ -16,18 +16,13 @@ Test error type string formatting.
 """
 
 # isort: STDLIB
-import argparse
 import unittest
 
 # isort: LOCAL
 from stratis_cli._errors import (
-    StratisCliActionError,
-    StratisCliEngineError,
-    StratisCliError,
     StratisCliGenerationError,
     StratisCliIncoherenceError,
     StratisCliPropertyNotFoundError,
-    StratisCliRuntimeError,
     StratisCliUnknownInterfaceError,
 )
 
@@ -43,18 +38,6 @@ class ErrorFmtTestCase(unittest.TestCase):
         :type exception: Exception
         """
         self.assertNotEqual(str(exception), "")
-
-    def testStratisCliErrorFmt(self):
-        """
-        Test 'StratisCliError'
-        """
-        self._string_not_empty(StratisCliError("Error"))
-
-    def testStratisCliRuntimeErrorFmt(self):
-        """
-        Test 'StratisCliRuntimeError'
-        """
-        self._string_not_empty(StratisCliRuntimeError("Error"))
 
     def testStratisCliPropertyNotFoundErrorFmt(self):
         """
@@ -75,20 +58,6 @@ class ErrorFmtTestCase(unittest.TestCase):
         Test 'StratisCliUnknownInterfaceError'
         """
         self._string_not_empty(StratisCliUnknownInterfaceError("BadInterface"))
-
-    def testTimeoutStratisCliEngineErrorFmt(self):
-        """
-        Test 'StratisCliEngineError'
-        """
-        self._string_not_empty(StratisCliEngineError(42, "Message"))
-
-    def testStratisCliActionErrorFmt(self):
-        """
-        Test 'StratisCliActionError'
-        """
-        self._string_not_empty(
-            StratisCliActionError(["CommandLineArgs"], argparse.ArgumentParser())
-        )
 
     def testStratisCliGenerationErrorFmt(self):
         """


### PR DESCRIPTION
Created an exit_() function to replace the standard SystemExit exception. This function will accept both a exit code and an error message, which will be printed to stderr. 

The exit_() function is now used within hande_error() and has been tested with the check_handle_error() function within one of the test_create.py unit tests. This check needs to be extended to other unit tests. 

Additionally, all other calls to sys.exit() should be replaced with exit_(). 

Related stratis-storage/stratis-cli#371 
Supersedes stratis-storage/stratis-cli#458 