### PR TITLE
Generalize exit

### DIFF
--- a/bin/stratis
+++ b/bin/stratis
@@ -23,6 +23,7 @@ try:
 
     from stratis_cli import run
     from stratis_cli import StratisCliEnvironmentError
+    from stratis_cli import StratisCliErrorCodes, exit_
 
     def main():
         """
@@ -34,10 +35,10 @@ try:
         main()
 
 except BrokenPipeError:
-    sys.exit("Broken pipe")
+    exit_(StratisCliErrorCodes.ERROR, "Broken pipe")
 
 except KeyboardInterrupt:
-    sys.exit("Received KeyboardInterrupt")
+    exit_(StratisCliErrorCodes.ERROR, "Received KeyboardInterrupt")
 
 except StratisCliEnvironmentError as err:
-    sys.exit("Value of STRATIS_DBUS_TIMEOUT invalid: %s" % err)
+    exit_(StratisCliErrorCodes.ERROR, "Value of STRATIS_DBUS_TIMEOUT invalid: %s" % err)

--- a/src/stratis_cli/__init__.py
+++ b/src/stratis_cli/__init__.py
@@ -16,3 +16,4 @@ Top level of CLI.
 """
 from ._main import run
 from ._errors import StratisCliEnvironmentError
+from ._error_reporting import StratisCliErrorCodes, handle_error, exit_

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -17,6 +17,7 @@ Facilities for managing and reporting errors.
 # isort: STDLIB
 import os
 import sys
+from enum import IntEnum
 
 # isort: THIRDPARTY
 import dbus
@@ -36,12 +37,31 @@ from ._errors import (
     StratisCliUserError,
 )
 
+
+class StratisCliErrorCodes(IntEnum):
+    """
+    StratisCli Error Codes
+    """
+
+    OK = 0
+    ERROR = 1
+    PARSE_ERROR = 2
+
+
 _DBUS_INTERFACE_MSG = (
     "The version of stratis you are running expects a different "
     "D-Bus interface than the one stratisd provides. Most likely "
     "you are running a version that requires a newer version of "
     "stratisd than you are running."
 )
+
+
+def exit_(code, msg):
+    """
+    Exits program with a given exit code and error message.
+    """
+    print(msg, os.linesep, file=sys.stderr, flush=True)
+    raise SystemExit(code)
 
 
 # pylint: disable=fixme
@@ -214,4 +234,4 @@ def handle_error(err):
         raise err
 
     exit_msg = "Execution failed:%s%s" % (os.linesep, explanation)
-    sys.exit(exit_msg)
+    exit_(StratisCliErrorCodes.ERROR, exit_msg)

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -64,9 +64,7 @@ def exit_(code, msg):
     raise SystemExit(code)
 
 
-# pylint: disable=fixme
-# FIXME: remove no coverage pragma when adequate testing for CLI output exists.
-def _interface_name_to_common_name(interface_name):  # pragma: no cover
+def _interface_name_to_common_name(interface_name):
     """
     Maps a D-Bus interface name to the common name that identifies the type
     of stratisd thing that the interface represents.
@@ -75,7 +73,10 @@ def _interface_name_to_common_name(interface_name):  # pragma: no cover
     :returns: a common name
     :rtype: str
     """
-    if interface_name == BLOCKDEV_INTERFACE:
+    # pylint: disable=fixme
+    # FIXME: remove no coverage pragma when adequate testing for CLI output
+    # exists.
+    if interface_name == BLOCKDEV_INTERFACE:  # pragma: no cover
         return "block device"
 
     if interface_name == FILESYSTEM_INTERFACE:
@@ -84,7 +85,8 @@ def _interface_name_to_common_name(interface_name):  # pragma: no cover
     if interface_name == POOL_INTERFACE:
         return "pool"
 
-    raise StratisCliUnknownInterfaceError(interface_name)
+    # This is a permanent no cover. There should never be an unknown interface.
+    raise StratisCliUnknownInterfaceError(interface_name)  # pragma: no cover
 
 
 def get_errors(exc):
@@ -111,10 +113,7 @@ def _interpret_errors(errors):
     :type errors: list of Exception
     :returns: None if no interpretation found, otherwise str
     """
-    # pylint: disable=fixme
-    # FIXME: remove no coverage pragma when adequate testing for CLI output
-    # exists.
-    try:  # pragma: no cover
+    try:
         # Inspect top-most error after StratisCliActionError
         error = errors[1]
 
@@ -169,11 +168,14 @@ def _interpret_errors(errors):
         # Inspect lowest error
         error = errors[-1]
 
+        # pylint: disable=fixme
+        # FIXME: remove no coverage pragma when adequate testing for CLI output
+        # exists.
         if (
             # pylint: disable=bad-continuation
             isinstance(error, dbus.exceptions.DBusException)
             and error.get_dbus_name() == "org.freedesktop.DBus.Error.AccessDenied"
-        ):
+        ):  # pragma: no cover
             return "Most likely stratis has insufficient permissions for the action requested."
         # We have observed two causes of this problem. The first is that
         # stratisd is not running at all. The second is that stratisd has not
@@ -185,11 +187,14 @@ def _interpret_errors(errors):
         ):
             return "Most likely stratis is unable to connect to the stratisd D-Bus service."
 
+        # pylint: disable=fixme
+        # FIXME: remove no coverage pragma when adequate testing for CLI output
+        # exists.
         if (
             # pylint: disable=bad-continuation
             isinstance(error, dbus.exceptions.DBusException)
             and error.get_dbus_name() == "org.freedesktop.DBus.Error.NoReply"
-        ):
+        ):  # pragma: no cover
             fmt_str = (
                 "stratis attempted communication with the daemon, stratisd, "
                 "over the D-Bus, but stratisd did not respond in the allowed time."

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -330,7 +330,9 @@ class StratisCliActionError(StratisCliRuntimeError):
         self.command_line_args = command_line_args
         self.namespace = namespace
 
-    def __str__(self):
+    # pylint: disable=fixme
+    # FIXME: remove no coverage pragma when adequate testing for CLI output
+    def __str__(self):  # pragma: no cover
         fmt_str = (
             "Action selected by command-line arguments %s which were "
             "parsed to %s failed"

--- a/tests/whitebox/integration/logical/test_create.py
+++ b/tests/whitebox/integration/logical/test_create.py
@@ -22,16 +22,13 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import (
-    StratisCliActionError,
-    StratisCliEngineError,
-    StratisCliPartialChangeError,
-)
-from stratis_cli._stratisd_constants import StratisdErrors
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._errors import StratisCliEngineError, StratisCliPartialChangeError
 
 from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -49,10 +46,7 @@ class CreateTestCase(SimTestCase):
         Creation of the volume must fail since pool is not specified.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -107,11 +101,7 @@ class Create3TestCase(SimTestCase):
         volume of the same name.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        with self.assertRaises(StratisCliEngineError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliEngineError)
-        self.assertEqual(cause.rc, StratisdErrors.ALREADY_EXISTS)
+        self.check_error(StratisCliEngineError, command_line, _ERROR)
 
 
 class Create4TestCase(SimTestCase):
@@ -141,11 +131,7 @@ class Create4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:2]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Create(self):
         """
@@ -154,11 +140,7 @@ class Create4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
 
 class Create5TestCase(SimTestCase):
@@ -193,11 +175,7 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Create(self):
         """
@@ -206,8 +184,4 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:4]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_destroy.py
+++ b/tests/whitebox/integration/logical/test_destroy.py
@@ -22,11 +22,13 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import StratisCliActionError, StratisCliPartialChangeError
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._errors import StratisCliPartialChangeError
 
 from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -45,10 +47,7 @@ class DestroyTestCase(SimTestCase):
         Destruction of the volume must fail since pool is not specified.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 @unittest.skip("Temporarily unable to create multiple filesystems at same time")
@@ -138,11 +137,7 @@ class Destroy4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Destroy(self):
         """
@@ -151,11 +146,7 @@ class Destroy4TestCase(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
 
 class Create5TestCase(SimTestCase):
@@ -190,11 +181,7 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:3]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def test2Destroy(self):
         """
@@ -203,8 +190,4 @@ class Create5TestCase(SimTestCase):
         There are multiple (2) target resources that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._VOLNAMES[0:4]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_list.py
+++ b/tests/whitebox/integration/logical/test_list.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test 'create'.
+Test 'list'.
 """
 
 # isort: STDLIB
@@ -22,7 +22,7 @@ import unittest
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import StratisCliActionError
+from stratis_cli import StratisCliErrorCodes
 
 from .._misc import RUNNER, SimTestCase, device_name_list
 
@@ -42,10 +42,9 @@ class ListTestCase(SimTestCase):
         Listing the volume must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(
+            DbusClientUniqueResultError, command_line, StratisCliErrorCodes.ERROR
+        )
 
 
 class List2TestCase(SimTestCase):

--- a/tests/whitebox/integration/logical/test_rename.py
+++ b/tests/whitebox/integration/logical/test_rename.py
@@ -19,11 +19,13 @@ Test 'rename'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import StratisCliActionError, StratisCliNoChangeError
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._errors import StratisCliNoChangeError
 
 from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class RenameTestCase(SimTestCase):
@@ -60,10 +62,7 @@ class RenameTestCase(SimTestCase):
         Renaming the filesystem must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNoChangeError)
+        self.check_error(StratisCliNoChangeError, command_line, _ERROR)
 
 
 class Rename1TestCase(SimTestCase):
@@ -81,20 +80,15 @@ class Rename1TestCase(SimTestCase):
         Renaming the filesystem must fail, because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
     def testNonExistentPoolSameName(self):
         """
         Renaming the filesystem must fail, because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Rename2TestCase(SimTestCase):
@@ -120,17 +114,11 @@ class Rename2TestCase(SimTestCase):
         Renaming the filesystem must fail, because filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
     def testNonExistentFilesystemSameName(self):
         """
         Renaming the filesystem must fail, because the filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._RENAMEFSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/logical/test_snapshot.py
+++ b/tests/whitebox/integration/logical/test_snapshot.py
@@ -19,11 +19,13 @@ Test 'snapshot'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import StratisCliActionError, StratisCliNoChangeError
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._errors import StratisCliNoChangeError
 
 from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class SnapshotTestCase(SimTestCase):
@@ -58,10 +60,7 @@ class SnapshotTestCase(SimTestCase):
         Creation of the snapshot must fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._FSNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNoChangeError)
+        self.check_error(StratisCliNoChangeError, command_line, _ERROR)
 
 
 class Snapshot1TestCase(SimTestCase):
@@ -79,10 +78,7 @@ class Snapshot1TestCase(SimTestCase):
         Creation of the snapshot must fail since specified pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Snapshot2TestCase(SimTestCase):
@@ -108,7 +104,4 @@ class Snapshot2TestCase(SimTestCase):
         Creation of the snapshot must fail since filesystem does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._FSNAME, self._SNAPNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/physical/test_list.py
+++ b/tests/whitebox/integration/physical/test_list.py
@@ -19,7 +19,7 @@ Test 'list'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import StratisCliActionError
+from stratis_cli import StratisCliErrorCodes
 
 from .._misc import RUNNER, SimTestCase, device_name_list
 
@@ -39,10 +39,9 @@ class ListTestCase(SimTestCase):
         Listing the devices must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(
+            DbusClientUniqueResultError, command_line, StratisCliErrorCodes.ERROR
+        )
 
     def testListEmpty(self):
         """

--- a/tests/whitebox/integration/pool/test_add.py
+++ b/tests/whitebox/integration/pool/test_add.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test 'create'.
+Test 'add'.
 """
 
 # isort: FIRSTPARTY
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import (
-    StratisCliActionError,
     StratisCliInUseOtherTierError,
     StratisCliInUseSameTierError,
     StratisCliPartialChangeError,
@@ -30,6 +30,7 @@ from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1, 1)
 _DEVICE_STRATEGY_2 = device_name_list(2, 2)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class AddDataTestCase(SimTestCase):
@@ -45,10 +46,7 @@ class AddDataTestCase(SimTestCase):
         Adding the devices must fail since the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class AddCacheTestCase(SimTestCase):
@@ -63,11 +61,9 @@ class AddCacheTestCase(SimTestCase):
         """
         Adding the devices must fail since the pool does not exist.
         """
+
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class AddDataTestCase1(SimTestCase):
@@ -99,10 +95,7 @@ class AddDataTestCase1(SimTestCase):
         There is 1 target resource that would not change.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def testAddDataCache(self):
         """
@@ -112,11 +105,11 @@ class AddDataTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY()
         command_line = ["--propagate", "pool", "add-cache"] + [self._POOLNAME] + devices
         RUNNER(command_line)
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(self._MENU + [self._POOLNAME] + devices)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseOtherTierError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(
+            StratisCliInUseOtherTierError,
+            self._MENU + [self._POOLNAME] + devices,
+            _ERROR,
+        )
 
     def testAddDataCache2(self):
         """
@@ -126,11 +119,11 @@ class AddDataTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY_2()
         command_line = ["--propagate", "pool", "add-cache"] + [self._POOLNAME] + devices
         RUNNER(command_line)
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(self._MENU + [self._POOLNAME] + devices)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseOtherTierError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(
+            StratisCliInUseOtherTierError,
+            self._MENU + [self._POOLNAME] + devices,
+            _ERROR,
+        )
 
 
 class AddDataTestCase2(SimTestCase):
@@ -157,11 +150,7 @@ class AddDataTestCase2(SimTestCase):
         Test that adding the same devices to the data tier in a different pool fails.
         """
         command_line = self._MENU + [self._POOLNAME] + self._SECOND_DEVICES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseSameTierError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliInUseSameTierError, command_line, _ERROR)
 
 
 class AddCacheTestCase1(SimTestCase):
@@ -195,11 +184,7 @@ class AddCacheTestCase1(SimTestCase):
         devices = _DEVICE_STRATEGY()
         command_line = self._MENU + [self._POOLNAME] + devices
         RUNNER(command_line)
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliPartialChangeError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
 
     def testAddCacheData(self):
         """
@@ -207,11 +192,7 @@ class AddCacheTestCase1(SimTestCase):
         an exception.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseOtherTierError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliInUseOtherTierError, command_line, _ERROR)
 
 
 class AddCacheTestCase2(SimTestCase):
@@ -234,8 +215,4 @@ class AddCacheTestCase2(SimTestCase):
         an exception.
         """
         command_line = self._MENU + [self._POOLNAME] + self._DEVICES_2
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseOtherTierError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliInUseOtherTierError, command_line, _ERROR)

--- a/tests/whitebox/integration/pool/test_create.py
+++ b/tests/whitebox/integration/pool/test_create.py
@@ -16,8 +16,8 @@ Test 'create'.
 """
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import (
-    StratisCliActionError,
     StratisCliInUseSameTierError,
     StratisCliNameConflictError,
 )
@@ -26,6 +26,7 @@ from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
 _DEVICE_STRATEGY_2 = device_name_list(2)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class Create3TestCase(SimTestCase):
@@ -51,11 +52,7 @@ class Create3TestCase(SimTestCase):
         new pool with the same devices and the same name as previous.
         """
         command_line = self._MENU + [self._POOLNAME] + self.devices
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNameConflictError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliNameConflictError, command_line, _ERROR)
 
     def testCreateDifferentDevices(self):
         """
@@ -63,11 +60,7 @@ class Create3TestCase(SimTestCase):
         new pool with different devices and the same name as previous.
         """
         command_line = self._MENU + [self._POOLNAME] + _DEVICE_STRATEGY()
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNameConflictError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliNameConflictError, command_line, _ERROR)
 
 
 class Create4TestCase(SimTestCase):
@@ -91,8 +84,4 @@ class Create4TestCase(SimTestCase):
         a StratisCliInUseSameTierError exception.
         """
         command_line = self._MENU + [self._POOLNAME_2] + self._DEVICES
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliInUseSameTierError)
-        self.assertNotEqual(str(cause), "")
+        self.check_error(StratisCliInUseSameTierError, command_line, _ERROR)

--- a/tests/whitebox/integration/pool/test_destroy.py
+++ b/tests/whitebox/integration/pool/test_destroy.py
@@ -19,12 +19,13 @@ Test 'destroy'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import StratisCliActionError, StratisCliEngineError
-from stratis_cli._stratisd_constants import StratisdErrors
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._errors import StratisCliEngineError
 
 from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class Destroy1TestCase(SimTestCase):
@@ -42,10 +43,7 @@ class Destroy1TestCase(SimTestCase):
         Destroy should fail because there is no object path for the pool.
         """
         command_line = self._MENU + [self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Destroy2TestCase(SimTestCase):
@@ -97,11 +95,7 @@ class Destroy3TestCase(SimTestCase):
         This should fail since it has a filesystem.
         """
         command_line = self._MENU + [self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliEngineError)
-        self.assertEqual(cause.rc, StratisdErrors.BUSY)
+        self.check_error(StratisCliEngineError, command_line, _ERROR)
 
     def testWithFilesystemRemoved(self):
         """

--- a/tests/whitebox/integration/pool/test_rename.py
+++ b/tests/whitebox/integration/pool/test_rename.py
@@ -19,11 +19,13 @@ Test 'rename'.
 from dbus_client_gen import DbusClientUniqueResultError
 
 # isort: LOCAL
-from stratis_cli._errors import StratisCliActionError, StratisCliNoChangeError
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._errors import StratisCliNoChangeError
 
 from .._misc import RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(1)
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class Rename1TestCase(SimTestCase):
@@ -40,20 +42,14 @@ class Rename1TestCase(SimTestCase):
         This should fail because original name does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._NEW_POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
     def testSameName(self):
         """
         Renaming to itself will fail because the pool does not exist.
         """
         command_line = self._MENU + [self._POOLNAME, self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)
 
 
 class Rename2TestCase(SimTestCase):
@@ -85,17 +81,11 @@ class Rename2TestCase(SimTestCase):
         This should fail, because this performs no action.
         """
         command_line = self._MENU + [self._POOLNAME, self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, StratisCliNoChangeError)
+        self.check_error(StratisCliNoChangeError, command_line, _ERROR)
 
     def testNonExistentPool(self):
         """
         This should fail, because this pool is not there.
         """
         command_line = self._MENU + ["nopool", self._POOLNAME]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, DbusClientUniqueResultError)
+        self.check_error(DbusClientUniqueResultError, command_line, _ERROR)

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -15,13 +15,15 @@
 Test command-line argument parsing.
 """
 
-# isort: STDLIB
-import unittest
+# isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 
-from ._misc import RUNNER, SimTestCase
+from ._misc import RUNNER, RunTestCase, SimTestCase
+
+_PARSE_ERROR = StratisCliErrorCodes.PARSE_ERROR
 
 
-class ParserTestCase(unittest.TestCase):
+class ParserTestCase(RunTestCase):
     """
     Test parser behavior. The behavior should be identical, regardless of
     whether the "--propagate" flag is set. That is, stratis should never produce
@@ -38,10 +40,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for command_line in [[], ["daemon"]]:
             for prefix in [[], ["--propagate"]]:
-                with self.assertRaises(SystemExit) as context:
-                    RUNNER(prefix + command_line)
-                exit_code = context.exception.code
-                self.assertEqual(exit_code, 2)
+                self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
     def testStratisTwoOptions(self):
         """
@@ -50,10 +49,7 @@ class ParserTestCase(unittest.TestCase):
         """
         for prefix in [[], ["--propagate"]]:
             command_line = ["daemon", "redundancy", "version"]
-            with self.assertRaises(SystemExit) as context:
-                RUNNER(prefix + command_line)
-            exit_code = context.exception.code
-            self.assertEqual(exit_code, 2)
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
     def testStratisBadSubcommand(self):
         """
@@ -68,10 +64,7 @@ class ParserTestCase(unittest.TestCase):
             ["filesystem", "notasub"],
         ]:
             for prefix in [[], ["--propagate"]]:
-                with self.assertRaises(SystemExit) as context:
-                    RUNNER(prefix + command_line)
-                exit_code = context.exception.code
-                self.assertEqual(exit_code, 2)
+                self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
     def testRedundancy(self):
         """
@@ -89,10 +82,7 @@ class ParserTestCase(unittest.TestCase):
         ]
 
         for prefix in [[], ["--propagate"]]:
-            with self.assertRaises(SystemExit) as context:
-                RUNNER(prefix + command_line)
-            exit_code = context.exception.code
-            self.assertEqual(exit_code, 2)
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
 
 class ParserSimTestCase(SimTestCase):

--- a/tests/whitebox/integration/test_stratis.py
+++ b/tests/whitebox/integration/test_stratis.py
@@ -15,16 +15,16 @@
 Test 'stratisd'.
 """
 
-# isort: STDLIB
-import unittest
-
 # isort: THIRDPARTY
 import dbus
 
 # isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
 from stratis_cli._errors import StratisCliActionError
 
-from ._misc import RUNNER, SimTestCase
+from ._misc import RUNNER, RunTestCase, SimTestCase
+
+_ERROR = StratisCliErrorCodes.ERROR
 
 
 class StratisTestCase(SimTestCase):
@@ -49,7 +49,7 @@ class StratisTestCase(SimTestCase):
         RUNNER(command_line)
 
 
-class PropagateTestCase(unittest.TestCase):
+class PropagateTestCase(RunTestCase):
     """
     Verify correct operation of --propagate flag.
     """
@@ -59,10 +59,7 @@ class PropagateTestCase(unittest.TestCase):
         If propagate is set, the expected exception will propagate.
         """
         command_line = ["--propagate", "daemon", "version"]
-        with self.assertRaises(StratisCliActionError) as context:
-            RUNNER(command_line)
-        cause = context.exception.__cause__
-        self.assertIsInstance(cause, dbus.exceptions.DBusException)
+        self.check_error(dbus.exceptions.DBusException, command_line, _ERROR)
 
     def testNotPropagate(self):
         """
@@ -92,8 +89,4 @@ class ErrorHandlingTestCase(SimTestCase):
         # If instead the exception chain is handed off to handle_error,
         # the exception is recognized, an error message is generated,
         # and the program exits with the message via SystemExit.
-        with self.assertRaises(SystemExit) as context:
-            RUNNER(command_line)
-        exit_code = context.exception.code
-        self.assertNotEqual(exit_code, 0)
-        self.assertIsNotNone(exit_code)
+        self.check_system_exit(command_line, _ERROR)

--- a/tests/whitebox/unittest/test_error_fmt.py
+++ b/tests/whitebox/unittest/test_error_fmt.py
@@ -16,18 +16,13 @@ Test error type string formatting.
 """
 
 # isort: STDLIB
-import argparse
 import unittest
 
 # isort: LOCAL
 from stratis_cli._errors import (
-    StratisCliActionError,
-    StratisCliEngineError,
-    StratisCliError,
     StratisCliGenerationError,
     StratisCliIncoherenceError,
     StratisCliPropertyNotFoundError,
-    StratisCliRuntimeError,
     StratisCliUnknownInterfaceError,
 )
 
@@ -43,18 +38,6 @@ class ErrorFmtTestCase(unittest.TestCase):
         :type exception: Exception
         """
         self.assertNotEqual(str(exception), "")
-
-    def testStratisCliErrorFmt(self):
-        """
-        Test 'StratisCliError'
-        """
-        self._string_not_empty(StratisCliError("Error"))
-
-    def testStratisCliRuntimeErrorFmt(self):
-        """
-        Test 'StratisCliRuntimeError'
-        """
-        self._string_not_empty(StratisCliRuntimeError("Error"))
 
     def testStratisCliPropertyNotFoundErrorFmt(self):
         """
@@ -75,20 +58,6 @@ class ErrorFmtTestCase(unittest.TestCase):
         Test 'StratisCliUnknownInterfaceError'
         """
         self._string_not_empty(StratisCliUnknownInterfaceError("BadInterface"))
-
-    def testTimeoutStratisCliEngineErrorFmt(self):
-        """
-        Test 'StratisCliEngineError'
-        """
-        self._string_not_empty(StratisCliEngineError(42, "Message"))
-
-    def testStratisCliActionErrorFmt(self):
-        """
-        Test 'StratisCliActionError'
-        """
-        self._string_not_empty(
-            StratisCliActionError(["CommandLineArgs"], argparse.ArgumentParser())
-        )
 
     def testStratisCliGenerationErrorFmt(self):
         """


### PR DESCRIPTION
For instances in which a SystemExit exception is raised,
it is useful to introduce a function that can be passed the error code
with which to exit the program, as well as the error message that is
printed to standard error. The SystemExit exception itself can only
accept either an exit code or a exit message, but not both, hence the
introduction of a new function.

Additionally, it is beneficial to have the error codes of the program
accessible as constants, especially if additional error codes are introduced
in the future.

Signed-off-by: Leah Leshchinsky <lleshchi@redhat.com>