### PR TITLE
Do not export handle_error from stratis-cli module

### DIFF
--- a/src/stratis_cli/__init__.py
+++ b/src/stratis_cli/__init__.py
@@ -16,4 +16,4 @@ Top level of CLI.
 """
 from ._main import run
 from ._errors import StratisCliEnvironmentError
-from ._error_reporting import StratisCliErrorCodes, handle_error, exit_
+from ._error_reporting import StratisCliErrorCodes, exit_

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -28,7 +28,8 @@ import unittest
 import psutil
 
 # isort: LOCAL
-from stratis_cli import handle_error, run
+from stratis_cli import run
+from stratis_cli._error_reporting import handle_error
 from stratis_cli._errors import StratisCliActionError
 
 try:


### PR DESCRIPTION
Follows #465.