### PR TITLE
Display some properties of the pool using an encoding

### DIFF
--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -91,6 +91,12 @@ Name::
 	  The name of the pool.
 Total Physical::
 	  The physical usage statistics for the pool (Total / Used / Free).
+Properties::
+          Boolean valued properties that the pool may have. Each property has
+          a two-letter camel-case code. If the pool does not have the
+          property, a '~', for negation, is prepended to the property code.
+          The property codes are: Ca - indicates the pool has a cache,
+          Cr - indicates the pool is encrypted.
 
 FIELDS for stratis filesystem list
 

--- a/src/stratis_cli/_actions/_constants.py
+++ b/src/stratis_cli/_actions/_constants.py
@@ -20,7 +20,7 @@ TOP_OBJECT = "/org/storage/stratis2"
 
 SECTOR_SIZE = 512
 
-FETCH_PROPERTIES_INTERFACE = "org.storage.stratis2.FetchProperties"
+FETCH_PROPERTIES_INTERFACE = "org.storage.stratis2.FetchProperties.r1"
 FILESYSTEM_INTERFACE = "org.storage.stratis2.filesystem"
-POOL_INTERFACE = "org.storage.stratis2.pool"
+POOL_INTERFACE = "org.storage.stratis2.pool.r1"
 BLOCKDEV_INTERFACE = "org.storage.stratis2.blockdev"

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -49,8 +49,8 @@ SPECS = {
 </method>
 </interface>
 """,
-    "org.storage.stratis2.FetchProperties": """
-<interface name="org.storage.stratis2.FetchProperties">
+    "org.storage.stratis2.FetchProperties.r1": """
+<interface name="org.storage.stratis2.FetchProperties.r1">
 <method name="GetAllProperties">
 <arg name="property_hash" type="a{s(bv)}" direction="out"/>
 </method>
@@ -86,8 +86,8 @@ SPECS = {
 </property>
 </interface>
 """,
-    "org.storage.stratis2.pool": """
-<interface name="org.storage.stratis2.pool">
+    "org.storage.stratis2.pool.r1": """
+<interface name="org.storage.stratis2.pool.r1">
 <method name="AddCacheDevs">
 <arg name="devices" type="as" direction="in"/>
 <arg name="results" type="(bao)" direction="out"/>
@@ -129,6 +129,9 @@ SPECS = {
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
 </property>
 <property name="Uuid" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+</property>
+<property name="Encrypted" type="b" access="read">
 <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
 </property>
 </interface>

--- a/src/stratis_cli/_actions/_top.py
+++ b/src/stratis_cli/_actions/_top.py
@@ -242,15 +242,50 @@ class TopActions:
                 else total_physical_free,
             )
 
+        def properties_string(mopool, props_map):
+            """
+            Make a string encoding some important properties of the pool
+
+            :param mopool: an object representing all the properties of the pool
+            :type mopool: MOPool
+            :param props_map: a map of properties returned by GetAllProperties
+            :type props_map: dict of str * any
+            """
+
+            def gen_string(b, code):
+                """
+                Generate the display string for a boolean property
+
+                :param bool b: whether the property is true or false
+                :param str code: the code to generate the string for
+                :returns: the generated string
+                :rtype: str
+                """
+                return " " + code if b else "~" + code
+
+            prop_list = []
+            prop_list.append(
+                gen_string(
+                    fetch_property(POOL_INTERFACE, props_map, "HasCache", lambda x: x),
+                    "Ca",
+                )
+            )
+            prop_list.append(gen_string(mopool.Encrypted(), "Cr"))
+            return ",".join(prop_list)
+
         tables = [
-            (mopool.Name(), physical_size_triple(props))
+            (
+                mopool.Name(),
+                physical_size_triple(props),
+                properties_string(mopool, props),
+            )
             for props, mopool in pools_with_props
         ]
 
         print_table(
-            ["Name", "Total Physical"],
+            ["Name", "Total Physical", "Properties"],
             sorted(tables, key=lambda entry: entry[0]),
-            ["<", ">"],
+            ["<", ">", ">"],
         )
 
     @staticmethod


### PR DESCRIPTION
The CLI display looks like this:

```
# PYTHONPATH=./src ./bin/stratis pool list
Name                  Total Physical   Properties
name         512 EiB / 0 B / 512 EiB   ~Ca,~Cr   
with_cache   512 EiB / 0 B / 512 EiB   Ca,~Cr    
```

Ca indicates that the pool has a cache, Cr indicates that the pool is encrypted.