### PR TITLE
Fix blackbox tests by calling init-cache first

### DIFF
--- a/tests/blackbox/stratisd_cert.py
+++ b/tests/blackbox/stratisd_cert.py
@@ -138,8 +138,10 @@ class StratisCertify(unittest.TestCase):
         Test adding cache to a pool.
         """
         pool_name = p_n()
-        pool_path = make_test_pool(pool_name, DISKS[0:2])
+        pool_path = make_test_pool(pool_name, DISKS[0:1])
 
+        (_, return_code, _) = StratisDbus.pool_init_cache(pool_path, DISKS[1:2])
+        self.assertEqual(return_code, dbus.UInt16(0))
         (_, return_code, _) = StratisDbus.pool_add_cache(pool_path, DISKS[2:3])
         self.assertEqual(return_code, dbus.UInt16(0))
 

--- a/tests/blackbox/testlib/dbus.py
+++ b/tests/blackbox/testlib/dbus.py
@@ -216,6 +216,21 @@ class StratisDbus:
         }
 
     @staticmethod
+    def pool_init_cache(pool_path, devices):
+        """
+        Initialize the cache for a pool with a list of devices.
+        :param str pool_path: The object path of the pool to which the cache device will be added
+        :param str devices: A list of devices that can be initialized as a cache device
+        :return: The return values of the InitCache call
+        :rtype: The D-Bus types (bao), q, and s
+        """
+        iface = dbus.Interface(
+            StratisDbus._BUS.get_object(StratisDbus._BUS_NAME, pool_path),
+            StratisDbus._POOL_IFACE,
+        )
+        return iface.InitCache(devices, timeout=StratisDbus._TIMEOUT)
+
+    @staticmethod
     def pool_add_cache(pool_path, devices):
         """
         Add a block device as a cache device


### PR DESCRIPTION
It looks like the stratisd tests called AddCacheDevs before InitCache. This will call both in the correct order and ensure that they each succeed.