### PR TITLE
Rework getting properties from FetchProperties result

### DIFF
--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -105,6 +105,8 @@ Properties::
           Boolean valued properties that the pool may have. Each property has
           a two-letter camel-case code. If the pool does not have the
           property, a '~', for negation, is prepended to the property code.
+          If the engine experienced an error when obtaining the property, a
+          "?", representing "unknown", is prepended to the property code.
           The property codes are: Ca - indicates the pool has a cache,
           Cr - indicates the pool is encrypted.
 

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -34,7 +34,7 @@ from ._constants import (
     FILESYSTEM_INTERFACE,
     POOL_INTERFACE,
 )
-from ._timeout import get_timeout
+from ._utils import get_timeout
 
 assert hasattr(sys.modules.get("stratis_cli"), "run"), (
     "This module is being loaded too eagerly. Make sure that loading it is "

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -61,7 +61,7 @@ def get_property(props, name, to_repr, default):
     :rtype: object
     """
     try:
-        return to_repr(fetch_property("dummmy", props, name))
+        return to_repr(fetch_property(props, name))
     # An exception should only be raised if the property can not be obtained.
     # This requires either running against an interface that does not support
     # the property or the engine encountering an error getting the property,

--- a/src/stratis_cli/_actions/_formatting.py
+++ b/src/stratis_cli/_actions/_formatting.py
@@ -18,7 +18,8 @@ Formatting for tables.
 # isort: STDLIB
 import sys
 
-from .._errors import StratisCliPropertyNotFoundError
+from .._errors import StratisCliEnginePropertyError, StratisCliPropertyNotFoundError
+from ._utils import fetch_property
 
 # If the wcwidth package is not available the wcswidth function will not
 # be available. In that case, use the standard function len where wcswidth
@@ -46,35 +47,31 @@ except ImportError:  # pragma: no cover
 TABLE_FAILURE_STRING = "FAILURE"
 
 
-def fetch_property(object_type, props, name, to_repr):
+def get_property(props, name, to_repr, default):
     """
-    Get a representation of a property fetched through FetchProperties interface
-
-    :param object_type: string representation of object type implementing FetchProperties
-    :type object_type: str
+    Get a representation of a property fetched through FetchProperties
     :param props: dictionary of property names mapped to values
-    :type props: dict of strs to (bool, object)
-    :param name: the name of the property
-    :type name: str
-    :param to_repr: function expecting one object argument to convert to some type
-    :type to_repr: function(object) -> object
-    :returns: object produced by to_repr or None
-    :raises StratisCliPropertyNotFoundError:
+    :type props: dict of str * (bool, object)
+    :param str name: the name of the property
+    :param to_repr: function expecting one object argument to convert
+    :type to_repr: object -> object
+    :param default: object to return in lieu of propagating an exception
+    :type default: object
+    :returns: object produced by to_repr or default
+    :rtype: object
     """
-    # Disable coverage for failure of the engine to successfully get a value
-    # or for a property not existing for a specified key. We can not force the
-    # engine error easily and should not force it these CLI tests. A KeyError
-    # can only be raised if there is a bug in the code or if the version of
-    # stratisd being run is not compatible with the version of the CLI being
-    # tested. We expect to avoid those conditions, and choose not to test for
-    # them.
     try:
-        (success, variant) = props[name]
-        if not success:
-            return None  # pragma: no cover
-        return to_repr(variant)
-    except KeyError:  # pragma: no cover
-        raise StratisCliPropertyNotFoundError(object_type, name)
+        return to_repr(fetch_property("dummmy", props, name))
+    # An exception should only be raised if the property can not be obtained.
+    # This requires either running against an interface that does not support
+    # the property or the engine encountering an error getting the property,
+    # or a bug in our code.
+    except (
+        # pylint: disable=bad-continuation
+        StratisCliEnginePropertyError,
+        StratisCliPropertyNotFoundError,
+    ):  # pragma: no cover
+        return default
 
 
 def _get_column_len(column_width, entry_len, entry_width):

--- a/src/stratis_cli/_actions/_logical.py
+++ b/src/stratis_cli/_actions/_logical.py
@@ -27,8 +27,8 @@ from .._errors import (
 )
 from .._stratisd_constants import StratisdErrors
 from ._connection import get_object
-from ._constants import FILESYSTEM_INTERFACE, TOP_OBJECT
-from ._formatting import TABLE_FAILURE_STRING, fetch_property, print_table
+from ._constants import TOP_OBJECT
+from ._formatting import TABLE_FAILURE_STRING, get_property, print_table
 
 
 class LogicalActions:
@@ -151,11 +151,8 @@ class LogicalActions:
             :returns: a string to display in the resulting list output
             :rtype: str
             """
-            filesystem_used = fetch_property(FILESYSTEM_INTERFACE, props, "Used", Range)
-            return (
-                TABLE_FAILURE_STRING
-                if filesystem_used is None
-                else str(filesystem_used)
+            return get_property(
+                props, "Used", lambda x: str(Range(x)), TABLE_FAILURE_STRING
             )
 
         tables = [

--- a/src/stratis_cli/_actions/_physical.py
+++ b/src/stratis_cli/_actions/_physical.py
@@ -20,8 +20,8 @@ from justbytes import Range
 
 from .._stratisd_constants import BLOCK_DEV_TIER_TO_NAME
 from ._connection import get_object
-from ._constants import BLOCKDEV_INTERFACE, TOP_OBJECT
-from ._formatting import TABLE_FAILURE_STRING, fetch_property, print_table
+from ._constants import TOP_OBJECT
+from ._formatting import TABLE_FAILURE_STRING, get_property, print_table
 
 
 class PhysicalActions:
@@ -88,10 +88,12 @@ class PhysicalActions:
             :returns: a string to display in the resulting list output
             :rtype: str
             """
-            physical_size = fetch_property(
-                BLOCKDEV_INTERFACE, props, "TotalPhysicalSize", Range
+            return get_property(
+                props,
+                "TotalPhysicalSize",
+                lambda x: str(Range(x)),
+                TABLE_FAILURE_STRING,
             )
-            return TABLE_FAILURE_STRING if physical_size is None else str(physical_size)
 
         tables = [
             [

--- a/src/stratis_cli/_actions/_utils.py
+++ b/src/stratis_cli/_actions/_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Function to parse the STRATIS_DBUS_TIMEOUT value read from the environment.
+Miscellaneous functions.
 """
 
 from .._errors import StratisCliEnvironmentError

--- a/src/stratis_cli/_actions/_utils.py
+++ b/src/stratis_cli/_actions/_utils.py
@@ -66,12 +66,10 @@ def get_timeout(value):
     return timeout_int / 1000
 
 
-def fetch_property(object_type, props, name):
+def fetch_property(props, name):
     """
     Get a property fetched through FetchProperties interface
 
-    :param object_type: string representation of object type implementing FetchProperties
-    :type object_type: str
     :param props: dictionary of property names mapped to values
     :type props: dict of strs to (bool, object)
     :param name: the name of the property
@@ -90,9 +88,7 @@ def fetch_property(object_type, props, name):
     try:
         (success, variant) = props[name]
         if not success:
-            raise StratisCliEnginePropertyError(
-                object_type, name, variant
-            )  # pragma: no cover
+            raise StratisCliEnginePropertyError(name, variant)  # pragma: no cover
         return variant
     except KeyError:  # pragma: no cover
-        raise StratisCliPropertyNotFoundError(object_type, name)
+        raise StratisCliPropertyNotFoundError(name)

--- a/src/stratis_cli/_actions/_utils.py
+++ b/src/stratis_cli/_actions/_utils.py
@@ -16,7 +16,11 @@
 Miscellaneous functions.
 """
 
-from .._errors import StratisCliEnvironmentError
+from .._errors import (
+    StratisCliEnginePropertyError,
+    StratisCliEnvironmentError,
+    StratisCliPropertyNotFoundError,
+)
 
 
 def get_timeout(value):
@@ -60,3 +64,35 @@ def get_timeout(value):
 
     # Convert from milliseconds to seconds
     return timeout_int / 1000
+
+
+def fetch_property(object_type, props, name):
+    """
+    Get a property fetched through FetchProperties interface
+
+    :param object_type: string representation of object type implementing FetchProperties
+    :type object_type: str
+    :param props: dictionary of property names mapped to values
+    :type props: dict of strs to (bool, object)
+    :param name: the name of the property
+    :type name: str
+    :returns: the object in the dict
+    :raises StratisCliPropertyNotFoundError:
+    :raises StratisCliEnginePropertyError:
+    """
+    # Disable coverage for failure of the engine to successfully get a value
+    # or for a property not existing for a specified key. We can not force the
+    # engine error easily and should not force it these CLI tests. A KeyError
+    # can only be raised if there is a bug in the code or if the version of
+    # stratisd being run is not compatible with the version of the CLI being
+    # tested. We expect to avoid those conditions, and choose not to test for
+    # them.
+    try:
+        (success, variant) = props[name]
+        if not success:
+            raise StratisCliEnginePropertyError(
+                object_type, name, variant
+            )  # pragma: no cover
+        return variant
+    except KeyError:  # pragma: no cover
+        raise StratisCliPropertyNotFoundError(object_type, name)

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -31,6 +31,7 @@ from dbus_client_gen import (
 from ._actions import BLOCKDEV_INTERFACE, FILESYSTEM_INTERFACE, POOL_INTERFACE
 from ._errors import (
     StratisCliEngineError,
+    StratisCliEnginePropertyError,
     StratisCliIncoherenceError,
     StratisCliUnknownInterfaceError,
     StratisCliUserError,
@@ -178,6 +179,11 @@ def _interpret_errors(errors):
                 "the D-Bus: %s."
             )
             return fmt_str % error
+
+        # This should arise only if the engine encounters an error while
+        # obtaining a property. Therefore, it is not tested.
+        if isinstance(error, StratisCliEnginePropertyError):  # pragma: no cover
+            return str(error)
 
         if isinstance(error, StratisCliUserError):
             fmt_str = "It appears that you issued an unintended command: %s"

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -48,22 +48,18 @@ class StratisCliPropertyNotFoundError(StratisCliRuntimeError):
     a property being unavailable via the FetchProperties interface.
     """
 
-    def __init__(self, iface_name, prop_name):
+    def __init__(self, prop_name):
         """ Initializer.
 
-            :param str type_name: the full name of the DBus interface that does not
-                                  support this property name
             :param str prop_name: the property that did not exist
         """
         # pylint: disable=super-init-not-called
-        self.iface_name = iface_name
         self.prop_name = prop_name
 
     def __str__(self):
         return (
             "The requested property '%s' was not found in the FetchProperties "
-            "result for object implementing interface %s"
-            % (self.prop_name, self.iface_name)
+            "result for a D-Bus object" % self.prop_name
         )
 
 
@@ -304,26 +300,23 @@ class StratisCliEnginePropertyError(StratisCliRuntimeError):
     is still transmitted.
     """
 
-    def __init__(self, iface_name, prop_name, message):
+    def __init__(self, prop_name, message):
         """ Initializer.
 
-            :param str type_name: the full name of the DBus interface that
-                                  supports this property name
             :param str prop_name: the property that could not be obtained
             :param str message: the error message returned by the engine in
                                 place of the property
         """
         # pylint: disable=super-init-not-called
-        self.iface_name = iface_name
         self.prop_name = prop_name
         self.message = message
 
     def __str__(self):
         return (
             "stratisd encountered the following error while obtaining the "
-            "requested property '%s' via the FetchProperties interface for an "
-            "object implementing the interface %s: %s"
-        ) % (self.prop_name, self.iface_name, self.message)
+            "requested property '%s' via the FetchProperties interface for a "
+            "D-Bus object: %s"
+        ) % (self.prop_name, self.message)
 
 
 class StratisCliEngineError(StratisCliRuntimeError):

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -41,11 +41,11 @@ class StratisCliUserError(StratisCliRuntimeError):
     """
 
 
-# This indicates a bug.
 class StratisCliPropertyNotFoundError(StratisCliRuntimeError):
     """
-    Exception raised when a requested property from FetchProperties DBus interface
-    does not exist.
+    Exception raised when a property can not be found in the result of
+    a FetchProperties call. This can be due to a bug in our code or to
+    a property being unavailable via the FetchProperties interface.
     """
 
     def __init__(self, iface_name, prop_name):
@@ -61,8 +61,9 @@ class StratisCliPropertyNotFoundError(StratisCliRuntimeError):
 
     def __str__(self):
         return (
-            "The requested property '%s' is not supported by FetchProperties "
-            "for object implementing interface %s" % (self.prop_name, self.iface_name)
+            "The requested property '%s' was not found in the FetchProperties "
+            "result for object implementing interface %s"
+            % (self.prop_name, self.iface_name)
         )
 
 
@@ -292,6 +293,37 @@ class StratisCliUnknownInterfaceError(StratisCliRuntimeError):
 
     def __str__(self):
         return "unexpected interface name %s" % self._interface_name
+
+
+class StratisCliEnginePropertyError(StratisCliRuntimeError):
+    """
+    Raised if there was a failure to obtain a property due to an error in
+    stratisd's engine.
+
+    In this case, stratisd does not return an error code, but an error message
+    is still transmitted.
+    """
+
+    def __init__(self, iface_name, prop_name, message):
+        """ Initializer.
+
+            :param str type_name: the full name of the DBus interface that
+                                  supports this property name
+            :param str prop_name: the property that could not be obtained
+            :param str message: the error message returned by the engine in
+                                place of the property
+        """
+        # pylint: disable=super-init-not-called
+        self.iface_name = iface_name
+        self.prop_name = prop_name
+        self.message = message
+
+    def __str__(self):
+        return (
+            "stratisd encountered the following error while obtaining the "
+            "requested property '%s' via the FetchProperties interface for an "
+            "object implementing the interface %s: %s"
+        ) % (self.prop_name, self.iface_name, self.message)
 
 
 class StratisCliEngineError(StratisCliRuntimeError):

--- a/tests/whitebox/integration/pool/test_list.py
+++ b/tests/whitebox/integration/pool/test_list.py
@@ -73,3 +73,13 @@ class List2TestCase(SimTestCase):
         """
         command_line = self._MENU[:-1]
         RUNNER(command_line)
+
+    def test_list_with_cache(self):
+        """
+        Test listing a pool with a cache. The purpose is to verify that
+        strings representing boolean values with a True value are handled.
+        """
+        command_line = ["pool", "init-cache", self._POOLNAME] + _DEVICE_STRATEGY()
+        RUNNER(command_line)
+        command_line = self._MENU
+        RUNNER(command_line)

--- a/tests/whitebox/unittest/test_error_fmt.py
+++ b/tests/whitebox/unittest/test_error_fmt.py
@@ -44,9 +44,7 @@ class ErrorFmtTestCase(unittest.TestCase):
         """
         Test 'StratisCliPropertyNotFoundError'
         """
-        self._string_not_empty(
-            StratisCliPropertyNotFoundError("BadInterface", "BadProperty")
-        )
+        self._string_not_empty(StratisCliPropertyNotFoundError("BadProperty"))
 
     def test_stratis_cli_incoherence_error_fmt(self):
         """
@@ -70,4 +68,4 @@ class ErrorFmtTestCase(unittest.TestCase):
         """
         Test 'StratisCliEnginePropertyError'
         """
-        self._string_not_empty(StratisCliEnginePropertyError("iface", "name", "whoops"))
+        self._string_not_empty(StratisCliEnginePropertyError("name", "whoops"))

--- a/tests/whitebox/unittest/test_error_fmt.py
+++ b/tests/whitebox/unittest/test_error_fmt.py
@@ -20,6 +20,7 @@ import unittest
 
 # isort: LOCAL
 from stratis_cli._errors import (
+    StratisCliEnginePropertyError,
     StratisCliGenerationError,
     StratisCliIncoherenceError,
     StratisCliPropertyNotFoundError,
@@ -64,3 +65,9 @@ class ErrorFmtTestCase(unittest.TestCase):
         Test 'StratisCliGenerationError'
         """
         self._string_not_empty(StratisCliGenerationError("Error"))
+
+    def test_stratis_cli_engine_property_error_fmt(self):
+        """
+        Test 'StratisCliEnginePropertyError'
+        """
+        self._string_not_empty(StratisCliEnginePropertyError("iface", "name", "whoops"))

--- a/tests/whitebox/unittest/test_timeout.py
+++ b/tests/whitebox/unittest/test_timeout.py
@@ -20,7 +20,7 @@ import unittest
 
 # isort: LOCAL
 from stratis_cli import StratisCliEnvironmentError
-from stratis_cli._actions._timeout import get_timeout
+from stratis_cli._actions._utils import get_timeout
 
 
 class TimeoutTestCase(unittest.TestCase):


### PR DESCRIPTION
This changes the method used to get a property from the result of a FetchProperties call for various listing methods, fixing a bunch of little mistakes that had crept in, and making the list code a bit more succinct.

It also exposes a revised ```fetch_properties``` method, which is expected to be used in an upcoming PR.

Supercedes #550