### PR TITLE
Make some improvements to check.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ UNITTEST_OPTS = --verbose
 .PHONY: lint
 lint:
 	./check.py check.py
+	./check.py setup.py
 	./check.py bin/stratis
 	./check.py src/stratis_cli
 	./check.py tests/blackbox/stratis_cli_cert.py

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ UNITTEST_OPTS = --verbose
 
 .PHONY: lint
 lint:
+	./check.py check.py
 	./check.py bin/stratis
 	./check.py src/stratis_cli
 	./check.py tests/blackbox/stratis_cli_cert.py

--- a/check.py
+++ b/check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # isort: STDLIB
 import argparse

--- a/check.py
+++ b/check.py
@@ -51,7 +51,6 @@ def get_parser():
     parser.add_argument(
         "package", choices=arg_map.keys(), help="designates the package to test"
     )
-    parser.add_argument("--ignore", help="ignore these files")
     return parser
 
 
@@ -61,10 +60,7 @@ def get_command(namespace):
 
     :param `Namespace` namespace: the namespace
     """
-    cmd = ["pylint", namespace.package] + arg_map[namespace.package]
-    if namespace.ignore:
-        cmd.append("--ignore=%s" % namespace.ignore)
-    return cmd
+    return ["pylint", namespace.package] + arg_map[namespace.package]
 
 
 def main():

--- a/check.py
+++ b/check.py
@@ -1,11 +1,20 @@
 #!/usr/bin/python3
 
+"""
+Invoke pylint with pre-selected-options.
+"""
+
 # isort: STDLIB
 import argparse
 import subprocess
 import sys
 
-arg_map = {
+ARG_MAP = {
+    "check.py": [
+        "--reports=no",
+        "--disable=I",
+        "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
+    ],
     "src/stratis_cli": [
         "--reports=no",
         "--disable=I",
@@ -49,7 +58,7 @@ def get_parser():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "package", choices=arg_map.keys(), help="designates the package to test"
+        "package", choices=ARG_MAP.keys(), help="designates the package to test"
     )
     return parser
 
@@ -60,10 +69,13 @@ def get_command(namespace):
 
     :param `Namespace` namespace: the namespace
     """
-    return ["pylint", namespace.package] + arg_map[namespace.package]
+    return ["pylint", namespace.package] + ARG_MAP[namespace.package]
 
 
 def main():
+    """
+    Run the linter on a single directory or file.
+    """
     args = get_parser().parse_args()
     return subprocess.call(get_command(args), stdout=sys.stdout)
 

--- a/check.py
+++ b/check.py
@@ -53,6 +53,19 @@ ARG_MAP = {
     ],
 }
 
+# FIXME: omit once disabling the new lint in the source # pylint: disable=fixme
+# See https://github.com/stratis-storage/project/issues/175
+try:
+    import pylint
+
+    if pylint.__pkginfo__.numversion == (2, 4, 4):
+        ARG_MAP["src/stratis_cli"].append("--disable=import-outside-toplevel")
+        ARG_MAP["tests/whitebox"].append("--disable=import-outside-toplevel")
+except ImportError:
+    # Must be running on Travis, and check.py is running outside the virtual
+    # environment
+    pass
+
 
 def get_parser():
     """

--- a/check.py
+++ b/check.py
@@ -15,6 +15,11 @@ ARG_MAP = {
         "--disable=I",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
     ],
+    "setup.py": [
+        "--reports=no",
+        "--disable=I",
+        "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
+    ],
     "src/stratis_cli": [
         "--reports=no",
         "--disable=I",

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,29 @@
+"""
+Python packaging file for setup tools.
+"""
+
 # isort: STDLIB
 import os
-import sys
 
 # isort: THIRDPARTY
 import setuptools
 
-if sys.version_info[0] < 3:
-    from codecs import open
-
 
 def local_file(name):
+    """
+    Function to obtain the relative path of a filename.
+    """
     return os.path.relpath(os.path.join(os.path.dirname(__file__), name))
 
 
 README = local_file("README.rst")
 
 with open(local_file("src/stratis_cli/_version.py")) as o:
-    exec(o.read())
+    exec(o.read())  # pylint: disable=exec-used
 
 setuptools.setup(
     name="stratis-cli",
-    version=__version__,
+    version=__version__,  # pylint: disable=undefined-variable
     author="Anne Mulhern",
     author_email="amulhern@redhat.com",
     description="prototype stratis cli",


### PR DESCRIPTION
These are various improvements to check.py and its use. The last change is a convenience for those wanting to run the script on Fedora 31, and we'll revert it when we have all moved up to Fedora 31.

Related: https://github.com/stratis-storage/project/issues/175