### PR TITLE
Improve error message on partial unlock failure

### DIFF
--- a/src/stratis_cli/_actions/_top.py
+++ b/src/stratis_cli/_actions/_top.py
@@ -35,6 +35,7 @@ from .._errors import (
     StratisCliNameConflictError,
     StratisCliNoChangeError,
     StratisCliPartialChangeError,
+    StratisCliPartialFailureError,
     StratisCliResourceNotFoundError,
 )
 from .._stratisd_constants import BlockDevTiers, StratisdErrors
@@ -819,14 +820,20 @@ class TopActions:
         # management of unlocked devices, so pool_uuid_list is always empty.
         errors = []  # pragma: no cover
         for uuid in pool_uuid_list:  # pragma: no cover
-            ((is_some, _), return_code, message) = Manager.Methods.UnlockPool(
-                proxy, {"pool_uuid": uuid}
-            )
+            (
+                (is_some, unlocked_pools),
+                return_code,
+                message,
+            ) = Manager.Methods.UnlockPool(proxy, {"pool_uuid": uuid})
 
             if return_code != StratisdErrors.OK:
-                errors.append(StratisCliEngineError(return_code, message))
+                errors.append(
+                    StratisCliPartialFailureError(
+                        "unlock", "pool with UUID %s" % uuid, error_message=message
+                    )
+                )
 
-            if not is_some:
+            if is_some and unlocked_pools == []:
                 raise StratisCliIncoherenceError(
                     (
                         "stratisd reported that some existing devices are locked but "

--- a/src/stratis_cli/_actions/_top.py
+++ b/src/stratis_cli/_actions/_top.py
@@ -821,7 +821,7 @@ class TopActions:
         errors = []  # pragma: no cover
         for uuid in pool_uuid_list:  # pragma: no cover
             (
-                (is_some, unlocked_pools),
+                (is_some, unlocked_devices),
                 return_code,
                 message,
             ) = Manager.Methods.UnlockPool(proxy, {"pool_uuid": uuid})
@@ -833,7 +833,7 @@ class TopActions:
                     )
                 )
 
-            if is_some and unlocked_pools == []:
+            if is_some and unlocked_devices == []:
                 raise StratisCliIncoherenceError(
                     (
                         "stratisd reported that some existing devices are locked but "
@@ -842,4 +842,4 @@ class TopActions:
                 )
 
         if errors != []:  # pragma: no cover
-            raise StratisCliAggregateError("unlock", "device", errors)
+            raise StratisCliAggregateError("unlock", "pool", errors)

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -452,10 +452,40 @@ class StratisCliAggregateError(StratisCliRuntimeError):
 
     def __str__(self):
         return (
-            "The operation '%s' on a resource of type %s failed. The following"
+            "The operation '%s' on a resource of type %s failed. The following "
             "errors occurred:\n%s"
         ) % (
             self.operation,
             self.type,
             os.linesep.join([str(error) for error in self.errors]),
         )
+
+
+class StratisCliPartialFailureError(StratisCliRuntimeError):
+    """
+    A non-fatal error to be reported at the end as part of a StratisCliAggregateError.
+    """
+
+    def __init__(self, action, identifier_string, error_message=None):
+        """
+        Initializer.
+        :param str action: the action that failed
+        :param str identifier_string: a string that uniquely identifies the resource
+                                      for which the action failed
+        :param error_message: an optional error message for the cause of the partial
+                              failure
+        :type error_message: NoneType or str
+        """
+        # pylint: disable=super-init-not-called
+        self.action = action
+        self.identifier_string = identifier_string
+        self.error_message = error_message
+
+    def __str__(self):
+        fmt_str = 'Partial action "%s" failed for %s' % (
+            self.action,
+            self.identifier_string,
+        )
+        if self.error_message is not None:
+            fmt_str += ": %s" % self.error_message
+        return fmt_str

--- a/tests/whitebox/unittest/test_error_fmt.py
+++ b/tests/whitebox/unittest/test_error_fmt.py
@@ -25,6 +25,7 @@ from stratis_cli._errors import (
     StratisCliEnginePropertyError,
     StratisCliGenerationError,
     StratisCliIncoherenceError,
+    StratisCliPartialFailureError,
     StratisCliPropertyNotFoundError,
     StratisCliUnknownInterfaceError,
 )
@@ -79,5 +80,18 @@ class ErrorFmtTestCase(unittest.TestCase):
         self._string_not_empty(
             StratisCliAggregateError(
                 "do lots of things", "toy", [StratisCliEngineError(1, "bad")]
+            )
+        )
+
+    def test_stratis_cli_partial_failure_error(self):
+        """
+        Test 'StratisCliPartialFailureError'
+        """
+        self._string_not_empty(
+            StratisCliPartialFailureError("action", "unique resource")
+        )
+        self._string_not_empty(
+            StratisCliPartialFailureError(
+                "action", "unique resource", "something failed"
             )
         )


### PR DESCRIPTION
Closes #618 

@drckeefe @mulkieran I'd like to get feedback prior to code review on the new (correct) error message. There was indeed a bug in stratis-cli where if any of the unlocks failed, the entire action would halt. This has been resolved and so, as you can see, multiple unlocks can fail but execution will continue and then the aggregate failures will be communicated at the end of execution:

```
Execution failed:
An iterative command generated one or more errors: The operation 'unlock' on a resource of type device failed. The following errors occurred:
Partial action "unlock" failed for pool with UUID 1cfaf238b3fd464f969a545073bee654: Cryptsetup error: IO error occurred: Invalid argument (os error 22)
Partial action "unlock" failed for pool with UUID 65cbf7d5cc314e3d8b2eddb2a02249c1: Cryptsetup error: IO error occurred: Invalid argument (os error 22) 
```

My main question is whether we want to make changes on the stratisd side to make the message returned from the stratisd engine (currently `Cryptsetup error: IO error occurred: Invalid argument (os error 22)`) more informative. I can definitely move the issue to `project` if we decide that this message is too unclear as it stands. My personal opinion is that I would not know why it failed to unlock if I didn't write the code so it may be worth trying to make it clearer but this will be hard given our lack of type-based error chaining and the fact that there could be multiple reasons that this would fail with `EINVAL` beyond simply the key not existing. My recommendation if we do take this approach is that we specifically check if the key description exists and return a custom error as this will probably be one of those common cases where we want to be very clear why this is failing.