### PR TITLE
Some improvements to update_introspection_data

### DIFF
--- a/developer_tools/update_introspection_data
+++ b/developer_tools/update_introspection_data
@@ -100,10 +100,14 @@ def _add_data(proxy, interfaces, table):
     """
     string_data = Introspectable.Methods.Introspect(proxy, {})
     xml_data = ET.fromstring(string_data)
-    for interface in xml_data:
-        interface_name = interface.attrib["name"]
-        if interface_name in interfaces:
-            table[interface_name] = ET.tostring(interface).decode("utf-8").rstrip(" \n")
+
+    for interface_name in interfaces:
+        interface = next(
+            interface
+            for interface in xml_data
+            if interface.attrib["name"] == interface_name
+        )
+        table[interface_name] = ET.tostring(interface).decode("utf-8").rstrip(" \n")
 
     if not (frozenset(interfaces) <= frozenset(table.keys())):
         exit(

--- a/developer_tools/update_introspection_data
+++ b/developer_tools/update_introspection_data
@@ -22,6 +22,7 @@ import xml.etree.ElementTree as ET
 
 # isort: THIRDPARTY
 import dbus
+from semantic_version import Version
 
 # isort: FIRSTPARTY
 from dbus_python_client_gen import make_class
@@ -76,16 +77,16 @@ Introspectable = make_class(
 Manager = make_class("Manager", ET.fromstring(SPECS[_MANAGER_IFACE]), _TIMEOUT)
 Pool = make_class("Pool", ET.fromstring(SPECS[_POOL_IFACE]), _TIMEOUT)
 
-# EDIT these fields to get the interfaces and revisions desired
-TOP_OBJECT_INTERFACES = [
-    "org.freedesktop.DBus.ObjectManager",
-    "org.storage.stratis2.FetchProperties.r4",
-    "org.storage.stratis2.Manager.r4",
-    "org.storage.stratis2.Report.r1",
+OBJECT_MANAGER_INTERFACE = "org.freedesktop.DBus.ObjectManager"
+
+TOP_OBJECT_INTERFACE_PREFIXES = [
+    "org.storage.stratis2.FetchProperties",
+    "org.storage.stratis2.Manager",
+    "org.storage.stratis2.Report",
 ]
-POOL_OBJECT_INTERFACES = ["org.storage.stratis2.pool.r3"]
-BLOCKDEV_OBJECT_INTERFACES = ["org.storage.stratis2.blockdev.r2"]
-FILESYSTEM_OBJECT_INTERFACES = ["org.storage.stratis2.filesystem"]
+POOL_OBJECT_INTERFACE_PREFIXES = ["org.storage.stratis2.pool"]
+BLOCKDEV_OBJECT_INTERFACE_PREFIXES = ["org.storage.stratis2.blockdev"]
+FILESYSTEM_OBJECT_INTERFACE_PREFIXES = ["org.storage.stratis2.filesystem"]
 
 
 def _add_data(proxy, interfaces, table):
@@ -123,6 +124,11 @@ def main():
 
     proxy = bus.get_object(_SERVICE, "/org/storage/stratis2", introspect=False)
 
+    revision = "r%d" % Version(Manager.Properties.Version.Get(proxy)).minor
+
+    def get_current_interfaces(interface_prefixes):
+        return ["%s.%s" % (prefix, revision) for prefix in interface_prefixes]
+
     (
         (_, (pool_object_path, dev_object_paths)),
         return_code,
@@ -159,10 +165,23 @@ def main():
         _SERVICE, filesystem_object_path, introspect=False
     )
 
-    _add_data(proxy, TOP_OBJECT_INTERFACES, specs)
-    _add_data(pool_proxy, POOL_OBJECT_INTERFACES, specs)
-    _add_data(blockdev_proxy, BLOCKDEV_OBJECT_INTERFACES, specs)
-    _add_data(filesystem_proxy, FILESYSTEM_OBJECT_INTERFACES, specs)
+    _add_data(
+        proxy,
+        [OBJECT_MANAGER_INTERFACE]
+        + get_current_interfaces(TOP_OBJECT_INTERFACE_PREFIXES),
+        specs,
+    )
+    _add_data(pool_proxy, get_current_interfaces(POOL_OBJECT_INTERFACE_PREFIXES), specs)
+    _add_data(
+        blockdev_proxy,
+        get_current_interfaces(BLOCKDEV_OBJECT_INTERFACE_PREFIXES),
+        specs,
+    )
+    _add_data(
+        filesystem_proxy,
+        get_current_interfaces(FILESYSTEM_OBJECT_INTERFACE_PREFIXES),
+        specs,
+    )
 
     print("SPECS = {")
 

--- a/developer_tools/update_introspection_data
+++ b/developer_tools/update_introspection_data
@@ -46,6 +46,9 @@ SPECS = {
 <arg name="return_code" type="q" direction="out"/>
 <arg name="return_string" type="s" direction="out"/>
 </method>
+<property name="Version" type="s" access="read">
+<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
+</property>
 </interface>
 """,
     "org.storage.stratis2.pool.r1": """

--- a/src/stratis_cli/_actions/_constants.py
+++ b/src/stratis_cli/_actions/_constants.py
@@ -22,12 +22,15 @@ TOP_OBJECT = "/org/storage/stratis2"
 
 SECTOR_SIZE = 512
 
-FETCH_PROPERTIES_INTERFACE = "org.storage.stratis2.FetchProperties.r4"
-FILESYSTEM_INTERFACE = "org.storage.stratis2.filesystem.r4"
-POOL_INTERFACE = "org.storage.stratis2.pool.r4"
-BLOCKDEV_INTERFACE = "org.storage.stratis2.blockdev.r4"
-REPORT_INTERFACE = "org.storage.stratis2.Report.r4"
-
 MAXIMUM_STRATISD_VERSION = "3.0.0"
 MINIMUM_STRATISD_VERSION = "2.4.0"
 assert Version(MINIMUM_STRATISD_VERSION) < Version(MAXIMUM_STRATISD_VERSION)
+
+REVISION = "r%s" % Version(MINIMUM_STRATISD_VERSION).minor
+
+BLOCKDEV_INTERFACE = "org.storage.stratis2.blockdev.%s" % REVISION
+FETCH_PROPERTIES_INTERFACE = "org.storage.stratis2.FetchProperties.%s" % REVISION
+FILESYSTEM_INTERFACE = "org.storage.stratis2.filesystem.%s" % REVISION
+MANAGER_INTERFACE = "org.storage.stratis2.Manager.%s" % REVISION
+POOL_INTERFACE = "org.storage.stratis2.pool.%s" % REVISION
+REPORT_INTERFACE = "org.storage.stratis2.Report.%s" % REVISION

--- a/src/stratis_cli/_actions/_constants.py
+++ b/src/stratis_cli/_actions/_constants.py
@@ -23,10 +23,10 @@ TOP_OBJECT = "/org/storage/stratis2"
 SECTOR_SIZE = 512
 
 FETCH_PROPERTIES_INTERFACE = "org.storage.stratis2.FetchProperties.r4"
-FILESYSTEM_INTERFACE = "org.storage.stratis2.filesystem"
-POOL_INTERFACE = "org.storage.stratis2.pool.r3"
-BLOCKDEV_INTERFACE = "org.storage.stratis2.blockdev.r2"
-REPORT_INTERFACE = "org.storage.stratis2.Report.r1"
+FILESYSTEM_INTERFACE = "org.storage.stratis2.filesystem.r4"
+POOL_INTERFACE = "org.storage.stratis2.pool.r4"
+BLOCKDEV_INTERFACE = "org.storage.stratis2.blockdev.r4"
+REPORT_INTERFACE = "org.storage.stratis2.Report.r4"
 
 MAXIMUM_STRATISD_VERSION = "3.0.0"
 MINIMUM_STRATISD_VERSION = "2.4.0"

--- a/src/stratis_cli/_actions/_data.py
+++ b/src/stratis_cli/_actions/_data.py
@@ -32,6 +32,7 @@ from ._constants import (
     BLOCKDEV_INTERFACE,
     FETCH_PROPERTIES_INTERFACE,
     FILESYSTEM_INTERFACE,
+    MANAGER_INTERFACE,
     POOL_INTERFACE,
     REPORT_INTERFACE,
 )
@@ -42,8 +43,6 @@ assert hasattr(sys.modules.get("stratis_cli"), "run"), (
     "This module is being loaded too eagerly. Make sure that loading it is "
     "deferred until after the stratis_cli module has been fully loaded."
 )
-
-_MANAGER_INTERFACE = "org.storage.stratis2.Manager.r4"
 
 DBUS_TIMEOUT_SECONDS = 120
 
@@ -75,7 +74,7 @@ try:
     MODev = managed_object_class("MODev", blockdev_spec)
     devs = mo_query_builder(blockdev_spec)
 
-    Manager = make_class("Manager", ET.fromstring(SPECS[_MANAGER_INTERFACE]), timeout)
+    Manager = make_class("Manager", ET.fromstring(SPECS[MANAGER_INTERFACE]), timeout)
 
     ObjectManager = make_class(
         "ObjectManager",

--- a/src/stratis_cli/_actions/_introspect.py
+++ b/src/stratis_cli/_actions/_introspect.py
@@ -70,8 +70,8 @@ SPECS = {
     </property>
   </interface>
 """,
-    "org.storage.stratis2.Report.r1": """
-<interface name="org.storage.stratis2.Report.r1">
+    "org.storage.stratis2.Report.r4": """
+<interface name="org.storage.stratis2.Report.r4">
     <method name="GetReport">
       <arg name="name" type="s" direction="in" />
       <arg name="result" type="s" direction="out" />
@@ -80,8 +80,8 @@ SPECS = {
     </method>
   </interface>
 """,
-    "org.storage.stratis2.blockdev.r2": """
-<interface name="org.storage.stratis2.blockdev.r2">
+    "org.storage.stratis2.blockdev.r4": """
+<interface name="org.storage.stratis2.blockdev.r4">
     <method name="SetUserInfo">
       <arg name="id" type="(bs)" direction="in" />
       <arg name="changed" type="(bs)" direction="out" />
@@ -114,8 +114,8 @@ SPECS = {
     </property>
   </interface>
 """,
-    "org.storage.stratis2.filesystem": """
-<interface name="org.storage.stratis2.filesystem">
+    "org.storage.stratis2.filesystem.r4": """
+<interface name="org.storage.stratis2.filesystem.r4">
     <method name="SetName">
       <arg name="name" type="s" direction="in" />
       <arg name="result" type="(bs)" direction="out" />
@@ -137,8 +137,8 @@ SPECS = {
     </property>
   </interface>
 """,
-    "org.storage.stratis2.pool.r3": """
-<interface name="org.storage.stratis2.pool.r3">
+    "org.storage.stratis2.pool.r4": """
+<interface name="org.storage.stratis2.pool.r4">
     <method name="AddCacheDevs">
       <arg name="devices" type="as" direction="in" />
       <arg name="results" type="(bao)" direction="out" />


### PR DESCRIPTION
Closes #731 

* In update_introspection_data calculates revision numbers from stratisd version number.
* Lookup required interface names in introspection data and not vice-versa.
* Update_interface.py to be consistent w/ current stratisd version
* Calculate revision numbers from required minimum stratisd minor version in stratis CLI