### PR TITLE
Allow user to set filesystem limit on a pool

### DIFF
--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -77,6 +77,9 @@ pool rebind keyring <pool_name> <keydesc>::
 pool unbind <(clevis|keyring)> <pool name> ::
      Unbind the devices in the specified pool from the specified encryption
      mechanism.
+pool set-fs-limit <pool name> <amount> ::
+     Set the limit on the number of file systems allowed per-pool. This number
+     may only be increased from its current value.
 pool explain <code> ::
      Explain any error code that might show up in the Alerts column when
      listing a pool.

--- a/src/stratis_cli/_actions/_introspect.py
+++ b/src/stratis_cli/_actions/_introspect.py
@@ -215,6 +215,9 @@ SPECS = {
     <property name="Encrypted" type="b" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
     </property>
+    <property name="FsLimit" type="t" access="readwrite">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true" />
+    </property>
     <property name="HasCache" type="b" access="read" />
     <property name="KeyDescription" type="(b(bs))" access="read" />
     <property name="Name" type="s" access="read" />

--- a/src/stratis_cli/_actions/_pool.py
+++ b/src/stratis_cli/_actions/_pool.py
@@ -591,6 +591,24 @@ class PoolActions:
             raise StratisCliAggregateError("unlock", "pool", errors)
 
     @staticmethod
+    def set_fs_limit(namespace):
+        """
+        Set the filesystem limit.
+        """
+        # pylint: disable=import-outside-toplevel
+        from ._data import ObjectManager, Pool, pools
+
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+        (pool_object_path, _) = next(
+            pools(props={"Name": namespace.pool_name})
+            .require_unique_match(True)
+            .search(managed_objects)
+        )
+
+        Pool.Properties.FsLimit.Set(get_object(pool_object_path), namespace.amount)
+
+    @staticmethod
     def explain_code(namespace):
         """
         Print an explanation of pool error code.

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -27,7 +27,11 @@ from dbus_client_gen import (
     DbusClientMissingSearchPropertiesError,
     DbusClientUniqueResultError,
 )
-from dbus_python_client_gen import DPClientInvocationError, DPClientMethodCallContext
+from dbus_python_client_gen import (
+    DPClientInvocationError,
+    DPClientMethodCallContext,
+    DPClientSetPropertyContext,
+)
 
 from ._actions import BLOCKDEV_INTERFACE, FILESYSTEM_INTERFACE, POOL_INTERFACE
 from ._errors import (
@@ -251,7 +255,7 @@ def _interpret_errors_1(
     return None  # pragma: no cover
 
 
-def _interpret_errors_2(errors):  # pragma: no cover
+def _interpret_errors_2(errors):
     """
     Interpret the error when it is known that the first error is a
     DPClientInvocationError
@@ -271,29 +275,33 @@ def _interpret_errors_2(errors):  # pragma: no cover
             # We do not test this error, as the only known way to cause it is
             # manipulation of selinux configuration, which is too laborious to
             # bother with at this time.
-            if next_error.get_dbus_name() == "org.freedesktop.DBus.Error.Disconnected":
+            if (
+                next_error.get_dbus_name() == "org.freedesktop.DBus.Error.Disconnected"
+            ):  # pragma: no cover
                 return (
                     "The D-Bus connection was disconnected during a "
                     "D-Bus interaction. Most likely, your selinux settings "
                     "prohibit that particular D-Bus interaction."
                 )
 
-            # We do not test this error, as the only known way to cause it is
-            # to spam the daemon with a succession of mutating commands from
-            # separate processes. The circumstances that cause this exception
-            # to be raised are a call to GetManagedObjects() that is initiated
-            # while a call that removes a filesystem or pool is in progress.
-            # In that case, the GetManagedObjects() call may process object
-            # paths that have not yet been removed and may encounter an error
-            # when calculating the object properties since the engine no longer
-            # has any record of the filesystem or pool.
             if next_error.get_dbus_name() == "org.freedesktop.DBus.Error.Failed":
                 context = error.context
+
+                # We do not test this error, as the only known way to cause it
+                # is to spam the daemon with a succession of mutating commands
+                # from separate processes. The circumstances that cause this
+                # exception to be raised are a call to GetManagedObjects() that
+                # is initiated while a call that removes a filesystem or pool
+                # is in progress. In that case, the GetManagedObjects() call
+                # may process object paths that have not yet been removed and
+                # may encounter an error when calculating the object properties
+                # since the engine no longer has any record of the filesystem
+                # or pool.
                 if (
                     error.interface_name == "org.freedesktop.DBus.ObjectManager"
                     and isinstance(context, DPClientMethodCallContext)
                     and context.method_name == "GetManagedObjects"
-                ):
+                ):  # pragma: no cover
                     return (
                         "A D-Bus method failed during execution of the "
                         "selected command. Most likely, the failure was due "
@@ -301,7 +309,21 @@ def _interpret_errors_2(errors):  # pragma: no cover
                         "and the command will succeed if run again."
                     )
 
-    return None
+                if isinstance(context, DPClientSetPropertyContext):
+                    fmt_str = (
+                        "stratisd failed to perform the operation that you "
+                        "requested, because it could not set the D-Bus "
+                        'property "%s" belonging to inteface "%s" to "%s". It '
+                        "returned the following error: %s."
+                    )
+                    return fmt_str % (
+                        context.property_name,
+                        error.interface_name,
+                        context.value,
+                        next_error.get_dbus_message(),
+                    )
+
+    return None  # pragma: no cover
 
 
 def _interpret_errors(errors):

--- a/src/stratis_cli/_parser/_pool.py
+++ b/src/stratis_cli/_parser/_pool.py
@@ -15,10 +15,28 @@
 Definition of pool actions to display in the CLI.
 """
 
+# isort: STDLIB
+from argparse import ArgumentTypeError
+
 from .._actions import BindActions, PoolActions
 from .._constants import PoolMaintenanceErrorCode
 from .._stratisd_constants import EncryptionMethod
 from ._bind import BIND_SUBCMDS, REBIND_SUBCMDS
+
+
+def _ensure_nat(arg):
+    """
+    Raise error if argument is not an natural number.
+    """
+    try:
+        result = int(arg)
+    except Exception as err:
+        raise ArgumentTypeError("Argument %s is not a natural number." % arg) from err
+
+    if result < 0:
+        raise ArgumentTypeError("Argument %s is not a natural number." % arg)
+    return result
+
 
 POOL_SUBCMDS = [
     (
@@ -246,6 +264,22 @@ POOL_SUBCMDS = [
                 )
             ],
             func=PoolActions.unlock_pools,
+        ),
+    ),
+    (
+        "set-fs-limit",
+        dict(
+            help="Set the maximum number of filesystems the pool can support.",
+            args=[
+                ("pool_name", dict(action="store", help="Pool name")),
+                (
+                    "amount",
+                    dict(
+                        action="store", type=_ensure_nat, help="Number of filesystems."
+                    ),
+                ),
+            ],
+            func=PoolActions.set_fs_limit,
         ),
     ),
     (

--- a/tests/whitebox/integration/pool/test_set_fs_limit.py
+++ b/tests/whitebox/integration/pool/test_set_fs_limit.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Red Hat, Inc.
+# Copyright 2022 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,13 +16,11 @@ Test 'set-fs-limit'.
 """
 
 # isort: FIRSTPARTY
-from dbus_client_gen import DbusClientUniqueResultError
+from dbus_python_client_gen import DPClientInvocationError
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import StratisCliEngineError, StratisCliPartialChangeError
 
-from .._keyutils import RandomKeyTmpFile
 from .._misc import RUNNER, TEST_RUNNER, SimTestCase, device_name_list
 
 _DEVICE_STRATEGY = device_name_list(2)
@@ -31,7 +29,7 @@ _ERROR = StratisCliErrorCodes.ERROR
 
 class SetFsLimitTestCase(SimTestCase):
     """
-    Test 'set-fs-limit' with different values. 
+    Test 'set-fs-limit' with different values.
     """
 
     _MENU = ["--propagate", "pool", "set-fs-limit"]
@@ -45,9 +43,16 @@ class SetFsLimitTestCase(SimTestCase):
         command_line = ["pool", "create", self._POOLNAME] + _DEVICE_STRATEGY()
         RUNNER(command_line)
 
-    def test_set_fs_limit_neg(self):
+    def test_set_fs_limit_small(self):
         """
-        Test setting the filesystem limit to a negative number.
+        Test setting the filesystem limit to a small number.
         """
-        command_line = self._MENU + [self._POOLNAME] + ["-1"] 
-        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)
+        command_line = self._MENU + [self._POOLNAME] + ["1"]
+        self.check_error(DPClientInvocationError, command_line, _ERROR)
+
+    def test_set_fs_limit_large(self):
+        """
+        Set the filesystem limit to a very large number.
+        """
+        command_line = self._MENU + [self._POOLNAME] + ["1000000"]
+        TEST_RUNNER(command_line)

--- a/tests/whitebox/integration/pool/test_set_fs_limit.py
+++ b/tests/whitebox/integration/pool/test_set_fs_limit.py
@@ -1,0 +1,53 @@
+# Copyright 2020 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test 'set-fs-limit'.
+"""
+
+# isort: FIRSTPARTY
+from dbus_client_gen import DbusClientUniqueResultError
+
+# isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._errors import StratisCliEngineError, StratisCliPartialChangeError
+
+from .._keyutils import RandomKeyTmpFile
+from .._misc import RUNNER, TEST_RUNNER, SimTestCase, device_name_list
+
+_DEVICE_STRATEGY = device_name_list(2)
+_ERROR = StratisCliErrorCodes.ERROR
+
+
+class SetFsLimitTestCase(SimTestCase):
+    """
+    Test 'set-fs-limit' with different values. 
+    """
+
+    _MENU = ["--propagate", "pool", "set-fs-limit"]
+    _POOLNAME = "thispool"
+
+    def setUp(self):
+        """
+        Start stratisd and set up a pool.
+        """
+        super().setUp()
+        command_line = ["pool", "create", self._POOLNAME] + _DEVICE_STRATEGY()
+        RUNNER(command_line)
+
+    def test_set_fs_limit_neg(self):
+        """
+        Test setting the filesystem limit to a negative number.
+        """
+        command_line = self._MENU + [self._POOLNAME] + ["-1"] 
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -113,6 +113,22 @@ class ParserTestCase(RunTestCase):
         for prefix in [[], ["--propagate"]]:
             self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
+    def test_negative_filesystem_limit(self):
+        """
+        Verify that a negative integer filesystem limit is rejected.
+        """
+        command_line = ["pool", "set-fs-limit", "thispool", "-1"]
+        for prefix in [[], ["-propagate"]]:
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
+
+    def test_non_integer_filesystem_limit(self):
+        """
+        Verify that a non_integer filesystem limit is rejected.
+        """
+        command_line = ["pool", "set-fs-limit", "thispool", "1.2"]
+        for prefix in [[], ["-propagate"]]:
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
+
     def test_explain_non_existent_code(self):
         """
         Verify parser error on bogus pool code.


### PR DESCRIPTION
Extends the CLI with a new command that allows the user to set the filesystem limit on a pool

* Does not make any change to the pool listing to show the filesystem limit. We anticipate that we may make a detailed pool view that will allow the user to see the filesystem limit and more detailed information about the pool usage.
* Does not make any change to the pool listing to show more detailed pool usage. We defer this and anticipate showing it in a detailed view. So, we stick to the Total/Used/Free view, where total is the total size of the all the data devices, used is the amount allocated to the mdv, and the two metadata devices + the amount actually used in the data device. Free is the difference between these two. I believe that the Free value overestimates by the relatively tiny amount of space required by Stratis metadata, but I'm willing to defer dealing with that problem until a later time. In any case, I believe this problem is much better dealt with on the stratisd side, and predates this PR by quite a bit.
* Adds additional tests as necessary.