### PR TITLE
Expand block size

### DIFF
--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -249,7 +249,11 @@ Physical Size::
 	  The total size of the device on which stratisd places Stratis
           metadata. If the device is encrypted, this size will be slightly
           smaller than the total size of the device specified by the user; it
-          will be the size of the associated dm-crypt device.
+          will be the size of the associated dm-crypt device. A second size will
+          be displayed in parentheses if stratisd has observed that the device
+          has a size that is different from the size that stratisd is making use
+          of. This can happen if, e.g., a RAID device was previously added to a
+          pool and has since been expanded.
 Tier::
 	  The data tier type ("Data" or "Cache")
 

--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -61,6 +61,12 @@ pool init-cache <pool_name> <blockdev> [<blockdev>..]::
 	 drives, such as SSDs, are used for this purpose.
 pool add-cache <pool_name> <blockdev> [<blockdev>..]::
 	 Add one or more blockdevs to an existing pool with an initialized cache.
+pool extend-data <pool_name> [--device-uuid <uuid>]::
+     Increase the pool's data capacity with additional storage space offered by
+     its component data devices through, e.g., expansion of a component RAID
+     device. Devices may be specified by their Stratis UUID. If no devices are
+     specified, then stratisd will attempt to make use of all data devices
+     belonging to the pool that appear to have been expanded.
 pool bind <(nbde|tang)> <pool name> <url> <(--thumbprint <thp> | --trust-url)>::
      Bind the devices in the specified pool to a supplementary encryption
      mechanism that uses NBDE (Network-Bound Disc Encryption). *tang* is

--- a/src/stratis_cli/_actions/_introspect.py
+++ b/src/stratis_cli/_actions/_introspect.py
@@ -97,6 +97,7 @@ SPECS = {
     <property name="InitializationTime" type="t" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
     </property>
+    <property name="NewPhysicalSize" type="(bs)" access="read" />
     <property name="PhysicalPath" type="s" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
     </property>
@@ -176,6 +177,12 @@ SPECS = {
     <method name="DestroyFilesystems">
       <arg name="filesystems" type="ao" direction="in" />
       <arg name="results" type="(bas)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="GrowPhysicalDevice">
+      <arg name="dev" type="s" direction="in" />
+      <arg name="results" type="b" direction="out" />
       <arg name="return_code" type="q" direction="out" />
       <arg name="return_string" type="s" direction="out" />
     </method>

--- a/src/stratis_cli/_actions/_physical.py
+++ b/src/stratis_cli/_actions/_physical.py
@@ -21,7 +21,7 @@ from justbytes import Range
 from .._stratisd_constants import BLOCK_DEV_TIER_TO_NAME
 from ._connection import get_object
 from ._constants import TOP_OBJECT
-from ._formatting import print_table
+from ._formatting import get_property, print_table
 
 
 class PhysicalActions:
@@ -90,11 +90,24 @@ class PhysicalActions:
                 else f"{physical_path} ({metadata_path})"
             )
 
+        def size(modev):
+            """
+            Return in-use size (observed size) if they are different, otherwise
+            just in-use size.
+            """
+            in_use_size = Range(modev.TotalPhysicalSize())
+            observed_size = get_property(modev.NewPhysicalSize(), Range, in_use_size)
+            return (
+                f"{str(in_use_size)}"
+                if in_use_size == observed_size
+                else f"{str(in_use_size)} ({str(observed_size)})"
+            )
+
         tables = [
             [
                 path_to_name[modev.Pool()],
                 paths(modev),
-                str(Range(modev.TotalPhysicalSize())),
+                size(modev),
                 BLOCK_DEV_TIER_TO_NAME(modev.Tier(), True),
             ]
             for modev in modevs

--- a/src/stratis_cli/_actions/_pool.py
+++ b/src/stratis_cli/_actions/_pool.py
@@ -873,7 +873,14 @@ class _List:
             return ", ".join(sorted(str(code) for code in error_codes))
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
-        if pool_uuid is None:
+
+        def get_pools_with_changed_devs():
+            """
+            Find pools where device sizes have increased or decreased.
+
+            :returns: a pair of sets, increased first, then decreased
+            :rtype: set * set
+            """
             (increased, decreased) = (set(), set())
             for (_, info) in devs().search(managed_objects):
                 modev = MODev(info)
@@ -883,6 +890,12 @@ class _List:
                     increased.add(modev.Pool())
                 if observed_size < size:  # pragma: no cover
                     decreased.add(modev.Pool())
+
+            return (increased, decreased)
+
+        if pool_uuid is None:
+
+            (increased, decreased) = get_pools_with_changed_devs()
 
             pools_with_props = [
                 (objpath, MOPool(info))

--- a/src/stratis_cli/_actions/_pool.py
+++ b/src/stratis_cli/_actions/_pool.py
@@ -18,6 +18,8 @@ Pool actions.
 # isort: STDLIB
 import os
 from collections import defaultdict
+from itertools import tee
+from uuid import UUID
 
 # isort: THIRDPARTY
 from justbytes import Range
@@ -534,6 +536,99 @@ class PoolActions:
                     f"devices requested: ({', '.join(blockdevs)})"
                 )
             )
+
+    @staticmethod
+    def extend_data(namespace):  # pylint: disable=too-many-locals
+        """
+        Extend the pool making use of the additional space offered by component
+        devices. Exit immediately if something unexpected happens.
+
+        :raises StratisCliPartialChangeError:
+        :raises StratisCliEngineError:
+        :raises StratisCliIncoherenceError:
+        """
+        # pylint: disable=import-outside-toplevel
+        from ._data import MODev, ObjectManager, Pool, devs, pools
+
+        proxy = get_object(TOP_OBJECT)
+        managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+        (pool_object_path, _) = next(
+            pools(props={"Name": namespace.pool_name})
+            .require_unique_match(True)
+            .search(managed_objects)
+        )
+
+        modevs = (
+            MODev(info)
+            for objpath, info in devs(props={"Pool": pool_object_path}).search(
+                managed_objects
+            )
+        )
+
+        def expandable(modev):
+            """
+            Return true if the new size is greater than total.
+
+            :param MODev modev: blockdev representation
+            :rtype: bool
+            :returns: True if new physical size is greater than in-use size.
+            """
+            new_size = get_property(modev.NewPhysicalSize(), Range, None)
+            return (
+                False
+                if new_size is None
+                else new_size > Range(modev.TotalPhysicalSize())
+            )
+
+        if namespace.device_uuid == []:
+            expand_modevs = (modev for modev in modevs if expandable(modev))
+
+        else:
+            device_uuids = frozenset(uuid.hex for uuid in namespace.device_uuid)
+            expand_modevs = [modev for modev in modevs if modev.Uuid() in device_uuids]
+
+            if len(expand_modevs) < len(device_uuids):
+                missing_uuids = device_uuids.difference(
+                    frozenset(UUID(modev.Uuid()) for modev in expand_modevs)
+                )
+
+                missing_uuids = ", ".join(str(UUID(uuid)) for uuid in missing_uuids)
+
+                raise StratisCliResourceNotFoundError(
+                    "extend-data", f"devices with UUIDs {missing_uuids}"
+                )
+
+            t_1, t_2 = tee(expand_modevs)
+            expandable_modevs, unexpandable_modevs = (
+                [modev for modev in t_1 if expandable(modev)],
+                [modev for modev in t_2 if not expandable(modev)],
+            )
+
+            if unexpandable_modevs:
+                raise StratisCliPartialChangeError(
+                    "extend-data",
+                    frozenset(str(UUID(modev.Uuid())) for modev in expandable_modevs),
+                    frozenset(str(UUID(modev.Uuid())) for modev in unexpandable_modevs),
+                )
+
+            expand_modevs = expandable_modevs  # pragma: no cover
+
+        for modev in expand_modevs:  # pragma: no cover
+            (changed, return_code, message) = Pool.Methods.GrowPhysicalDevice(
+                get_object(pool_object_path), {"dev": modev.Uuid()}
+            )
+
+            if return_code != StratisdErrors.OK:
+                raise StratisCliEngineError(return_code, message)
+
+            if not changed:
+                raise StratisCliIncoherenceError(
+                    (
+                        f"Actual size of device with UUID {UUID(modev.Uuid())} "
+                        "appeared to be different from in-use size but no "
+                        "action was taken on the device."
+                    )
+                )
 
     @staticmethod
     def set_fs_limit(namespace):

--- a/src/stratis_cli/_error_codes.py
+++ b/src/stratis_cli/_error_codes.py
@@ -99,12 +99,64 @@ class PoolAllocSpaceErrorCode(IntEnum):
         )
 
 
+class PoolDeviceSizeChangeCode(IntEnum):
+    """
+    Codes to extend if a device
+    """
+
+    DEVICE_SIZE_INCREASED = 1
+    DEVICE_SIZE_DECREASED = 2
+
+    def __str__(self):
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED:
+            return f"IDS{str(self.value).zfill(3)}"
+
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED:
+            return f"WDS{str(self.value).zfill(3)}"
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    def explain(self):
+        """
+        Return an explanation of the return code.
+        """
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED:
+            return (
+                "At least one device belonging to this pool appears to have "
+                "increased in size."
+            )
+
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED:
+            return (
+                "At least one device belonging to this pool appears to have "
+                "decreased in size."
+            )
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    @staticmethod
+    def from_str(code_str):
+        """
+        Discover the code, if any, from the code string.
+
+        :returns: the code if it finds a match, otherwise None
+        :rtype: PoolAllocSpaceErrorCode or NoneType
+        """
+        return next(
+            (code for code in PoolDeviceSizeChangeCode if code_str == str(code)), None
+        )
+
+
 class PoolErrorCode:
     """
     Summary class for all pool error codes.
     """
 
-    CLASSES = [PoolMaintenanceErrorCode, PoolAllocSpaceErrorCode]
+    CLASSES = [
+        PoolMaintenanceErrorCode,
+        PoolAllocSpaceErrorCode,
+        PoolDeviceSizeChangeCode,
+    ]
 
     @staticmethod
     def codes():

--- a/src/stratis_cli/_parser/_pool.py
+++ b/src/stratis_cli/_parser/_pool.py
@@ -284,6 +284,36 @@ POOL_SUBCMDS = [
         ),
     ),
     (
+        "extend-data",
+        dict(
+            help=(
+                "Extend the pool's data capacity with additional storage "
+                "space offered by its component data devices through, e.g., "
+                "expansion of a component RAID device."
+            ),
+            args=[
+                ("pool_name", dict(action="store", help="Pool name")),
+                (
+                    "--device-uuid",
+                    dict(
+                        action="extend",
+                        dest="device_uuid",
+                        nargs="*",
+                        type=UUID,
+                        default=[],
+                        help=(
+                            "UUID of device to use; may be specified multiple "
+                            "times. If no devices specified then all devices "
+                            "belonging to the pool that appear to be have been "
+                            "expanded will be used."
+                        ),
+                    ),
+                ),
+            ],
+            func=PoolActions.extend_data,
+        ),
+    ),
+    (
         "bind",
         dict(
             help="Bind the given pool with an additional encryption facility",

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -300,6 +300,23 @@ def get_pool(proxy, pool_name):
     )
 
 
+def get_pool_blockdevs(proxy, pool_name):
+    """
+    Get a generator of blockdevs for a given pool.
+    """
+    pool_object_path, _ = get_pool(proxy, pool_name)
+
+    # pylint: disable=import-outside-toplevel
+    # isort: LOCAL
+    from stratis_cli._actions._data import MODev, ObjectManager, devs
+
+    managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+    return (
+        (op, MODev(info))
+        for (op, info) in devs(props={"Pool": pool_object_path}).search(managed_objects)
+    )
+
+
 def stop_pool(pool_name):
     """
     Stop a pool and return the UUID of the pool.

--- a/tests/whitebox/integration/pool/test_extend.py
+++ b/tests/whitebox/integration/pool/test_extend.py
@@ -1,0 +1,78 @@
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test 'extend-data'.
+"""
+
+# isort: STDLIB
+from uuid import UUID, uuid4
+
+# isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._actions._connection import get_object
+from stratis_cli._actions._constants import TOP_OBJECT
+from stratis_cli._errors import (
+    StratisCliPartialChangeError,
+    StratisCliResourceNotFoundError,
+)
+
+from .._misc import (
+    RUNNER,
+    TEST_RUNNER,
+    SimTestCase,
+    device_name_list,
+    get_pool_blockdevs,
+)
+
+_ERROR = StratisCliErrorCodes.ERROR
+_DEVICE_STRATEGY = device_name_list(1, 1)
+
+
+class ExtendDataTestCase(SimTestCase):
+    """
+    Test 'extend-data' on a sim pool.
+    """
+
+    _MENU = ["--propagate", "pool", "extend-data"]
+    _POOLNAME = "poolname"
+
+    def setUp(self):
+        super().setUp()
+        command_line = ["pool", "create", self._POOLNAME] + _DEVICE_STRATEGY()
+        RUNNER(command_line)
+
+    def test_bad_uuid(self):
+        """
+        Test trying to extend a device specifying a non-existent device UUID.
+        """
+        command_line = self._MENU + [self._POOLNAME, f"--device-uuid={str(uuid4())}"]
+        self.check_error(StratisCliResourceNotFoundError, command_line, _ERROR)
+
+    def test_no_uuid(self):
+        """
+        Test trying to extend a pool without specifying a UUID.
+        """
+        command_line = self._MENU + [self._POOLNAME]
+        TEST_RUNNER(command_line)
+
+    def test_good_uuid(self):
+        """
+        Test trying to extend a device specifying an existing device UUID.
+        """
+        _, props = next(get_pool_blockdevs(get_object(TOP_OBJECT), self._POOLNAME))
+        command_line = self._MENU + [
+            self._POOLNAME,
+            f"--device-uuid={str(UUID(props.Uuid()))}",
+        ]
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -203,6 +203,14 @@ class TestBadlyFormattedUuid(RunTestCase):
         for prefix in [[], ["--propagate"]]:
             self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
+    def test_bad_uuid_blockdev_2(self):
+        """
+        Test badly formed UUID for blockdev on extend-data.
+        """
+        command_line = ["pool", "extend-data", "poolname", "--device-uuid=not"]
+        for prefix in [[], ["--propagate"]]:
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
+
 
 class ParserSimTestCase(SimTestCase):
     """


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/50

Implements a new command: ```stratis pool extend-data``` and extends the output of ```blockdev list``` and ```pool list```. ```blockdev list``` shows the new size of the pool if different from the current in use-size. ```pool list``` displays an Alert on the pool, if different.