### PR TITLE
Allow user to expand pool if block device is expanded

### DIFF
--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -249,7 +249,11 @@ Physical Size::
 	  The total size of the device on which stratisd places Stratis
           metadata. If the device is encrypted, this size will be slightly
           smaller than the total size of the device specified by the user; it
-          will be the size of the associated dm-crypt device.
+          will be the size of the associated dm-crypt device. A second size will
+          be displayed in parentheses if stratisd has observed that the device
+          has a size that is different from the size that stratisd is making use
+          of. This can happen if, e.g., a RAID device was previously added to a
+          pool and has since been expanded.
 Tier::
 	  The data tier type ("Data" or "Cache")
 

--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -96,8 +96,8 @@ pool overprovision <pool name> <(yes|no)> ::
      available.
 pool explain <code> ::
      Explain any code that might show up in the Alerts column when
-     listing a pool. Codes may be prefixed with a "W", for "warning", or an "E",
-     for "error".
+     listing a pool. Codes may be prefixed with an "I" for "info", a "W" for
+     "warning", or an "E" for "error".
 pool debug get-object-path <(--uuid <uuid> |--name <name>)> ::
      Look up the D-Bus object path for a pool given the UUID or name.
 filesystem create <pool_name> <fs_name> [<fs_name>..] [--size <size>]::

--- a/docs/stratis.txt
+++ b/docs/stratis.txt
@@ -61,6 +61,12 @@ pool init-cache <pool_name> <blockdev> [<blockdev>..]::
 	 drives, such as SSDs, are used for this purpose.
 pool add-cache <pool_name> <blockdev> [<blockdev>..]::
 	 Add one or more blockdevs to an existing pool with an initialized cache.
+pool extend-data <pool_name> [--device-uuid <uuid>]::
+     Increase the pool's data capacity with additional storage space offered by
+     its component data devices through, e.g., expansion of a component RAID
+     device. Devices may be specified by their Stratis UUID. If no devices are
+     specified, then stratisd will attempt to make use of all data devices
+     belonging to the pool that appear to have been expanded.
 pool bind <(nbde|tang)> <pool name> <url> <(--thumbprint <thp> | --trust-url)>::
      Bind the devices in the specified pool to a supplementary encryption
      mechanism that uses NBDE (Network-Bound Disc Encryption). *tang* is

--- a/src/stratis_cli/_actions/_introspect.py
+++ b/src/stratis_cli/_actions/_introspect.py
@@ -97,6 +97,7 @@ SPECS = {
     <property name="InitializationTime" type="t" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
     </property>
+    <property name="NewPhysicalSize" type="(bs)" access="read" />
     <property name="PhysicalPath" type="s" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const" />
     </property>
@@ -176,6 +177,12 @@ SPECS = {
     <method name="DestroyFilesystems">
       <arg name="filesystems" type="ao" direction="in" />
       <arg name="results" type="(bas)" direction="out" />
+      <arg name="return_code" type="q" direction="out" />
+      <arg name="return_string" type="s" direction="out" />
+    </method>
+    <method name="GrowPhysicalDevice">
+      <arg name="dev" type="s" direction="in" />
+      <arg name="results" type="b" direction="out" />
       <arg name="return_code" type="q" direction="out" />
       <arg name="return_string" type="s" direction="out" />
     </method>

--- a/src/stratis_cli/_actions/_physical.py
+++ b/src/stratis_cli/_actions/_physical.py
@@ -21,7 +21,7 @@ from justbytes import Range
 from .._stratisd_constants import BLOCK_DEV_TIER_TO_NAME
 from ._connection import get_object
 from ._constants import TOP_OBJECT
-from ._formatting import print_table
+from ._formatting import get_property, print_table
 
 
 class PhysicalActions:
@@ -90,11 +90,24 @@ class PhysicalActions:
                 else f"{physical_path} ({metadata_path})"
             )
 
+        def size(modev):
+            """
+            Return in-use size (observed size) if they are different, otherwise
+            just in-use size.
+            """
+            in_use_size = Range(modev.TotalPhysicalSize())
+            observed_size = get_property(modev.NewPhysicalSize(), Range, in_use_size)
+            return (
+                f"{str(in_use_size)}"
+                if in_use_size == observed_size
+                else f"{str(in_use_size)} ({str(observed_size)})"
+            )
+
         tables = [
             [
                 path_to_name[modev.Pool()],
                 paths(modev),
-                str(Range(modev.TotalPhysicalSize())),
+                size(modev),
                 BLOCK_DEV_TIER_TO_NAME(modev.Tier(), True),
             ]
             for modev in modevs

--- a/src/stratis_cli/_actions/_pool.py
+++ b/src/stratis_cli/_actions/_pool.py
@@ -14,6 +14,7 @@
 """
 Pool actions.
 """
+# pylint: disable=too-many-lines
 
 # isort: STDLIB
 import os
@@ -25,7 +26,11 @@ from uuid import UUID
 from justbytes import Range
 
 from .._constants import YesOrNo
-from .._error_codes import PoolAllocSpaceErrorCode, PoolErrorCode
+from .._error_codes import (
+    PoolAllocSpaceErrorCode,
+    PoolDeviceSizeChangeCode,
+    PoolErrorCode,
+)
 from .._errors import (
     StratisCliEngineError,
     StratisCliFsLimitChangeError,
@@ -723,34 +728,30 @@ class _List:
         return _List._maybe_inconsistent(value, my_func)
 
     @staticmethod
-    def alert_string(mopool):
+    def alert_string(codes):
         """
         Alert information to display, if any
 
-        :param mopool: object to access pool properties
+        :param codes: list of error codes to display
+        :type codes: list of PoolErrorCode
 
         :returns: string w/ alert information, "" if no alert
         :rtype: str
         """
-        error_codes = _List.alert_codes(mopool)
-
-        return ", ".join(sorted(str(code) for code in error_codes))
+        return ", ".join(sorted(str(code) for code in codes))
 
     @staticmethod
-    def alert_summary(mopool):
+    def alert_summary(codes):
         """
         Alert summary to display, if any
-        :param mopool: object to access pool properties
+
+        :param codes: list of error codes to display
+        :type codes: list of PoolErrorCode
 
         :returns: string with alert summary
         :rtype: str
         """
-        error_codes = _List.alert_codes(mopool)
-
-        output = [f"    {str(code)}: {code.summarize()}" for code in error_codes]
-        output.insert(0, str(len(error_codes)))
-
-        return output
+        return [f"{str(code)}: {code.summarize()}" for code in codes]
 
     @staticmethod
     def alert_codes(mopool):
@@ -768,22 +769,84 @@ class _List:
             [PoolAllocSpaceErrorCode.NO_ALLOC_SPACE] if mopool.NoAllocSpace() else []
         )
 
-        error_codes = availability_error_codes + no_alloc_space_error_codes
+        return availability_error_codes + no_alloc_space_error_codes
 
-        return error_codes
+    @staticmethod
+    def _pools_with_changed_devs(devs_to_search):
+        """
+        Returns a tuple of sets containing (1) pools that have a device that
+        has increased in size and (2) pools that have a device that has
+        decreased in size.
 
-    def _print_detail_view(self, pool_uuid, mopool):
+        A pool may occupy both sets if one device has increased and one has
+        decreased.
+
+        :param devs_to_search: an iterable of device objects
+        :returns: a pair of sets
+        :rtype: tuple of (set of ObjectPath)
+        """
+        # pylint: disable=import-outside-toplevel
+        from ._data import MODev
+
+        (increased, decreased) = (set(), set())
+        for (_, info) in devs_to_search:
+            modev = MODev(info)
+            size = Range(modev.TotalPhysicalSize())
+            observed_size = get_property(modev.NewPhysicalSize(), Range, size)
+            if observed_size > size:  # pragma: no cover
+                increased.add(modev.Pool())
+            if observed_size < size:  # pragma: no cover
+                decreased.add(modev.Pool())
+
+        return (increased, decreased)
+
+    @staticmethod
+    def _from_sets(pool_object_path, increased, decreased):
+        """
+        Get the code from sets and one pool object path.
+
+        :param pool_object_path: the pool object path
+        :param increased: pools that have devices that have increased in size
+        :type increased: set of object path
+        :param decreased: pools that have devices that have decrease in size
+        :type increased: set of object path
+
+        :returns: the codes
+        """
+        if (
+            pool_object_path in increased and pool_object_path in decreased
+        ):  # pragma: no cover
+            return [
+                PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED,
+                PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED,
+            ]
+        if pool_object_path in increased:  # pragma: no cover
+            return [PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED]
+        if pool_object_path in decreased:  # pragma: no cover
+            return [PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED]
+        return []
+
+    def _print_detail_view(self, pool_uuid, mopool, size_change_codes):
         """
         Print the detailed view for a single pool.
 
         :param UUID uuid: the pool uuid
         :param MOPool mopool: properties of the pool
+        :param size_change_codes: size change codes
+        :type size_change_codes: list of PoolDeviceSizeChangeCode
         """
         encrypted = mopool.Encrypted()
 
         print(f"UUID: {self.uuid_formatter(pool_uuid)}")
         print(f"Name: {mopool.Name()}")
-        print(f"Alerts: {os.linesep.join(_List.alert_summary(mopool))}")
+
+        alert_summary = _List.alert_summary(
+            _List.alert_codes(mopool) + size_change_codes
+        )
+        print(f"Alerts: {str(len(alert_summary))}")
+        for line in alert_summary:  # pragma: no cover
+            print(f"     {line}")
+
         print(
             f"Actions Allowed: "
             f"{PoolActionAvailability.from_str(mopool.AvailableActions())}"
@@ -823,12 +886,12 @@ class _List:
 
         print(f"    Used: {total_physical_used_str}")
 
-    def list_pools_default(self, *, pool_uuid=None):
+    def list_pools_default(self, *, pool_uuid=None):  # pylint: disable=too-many-locals
         """
         List all pools that are listed by default. These are all started pools.
         """
         # pylint: disable=import-outside-toplevel
-        from ._data import MOPool, ObjectManager, pools
+        from ._data import MOPool, ObjectManager, devs, pools
 
         proxy = get_object(TOP_OBJECT)
 
@@ -888,8 +951,13 @@ class _List:
 
         managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
         if pool_uuid is None:
+            (increased, decreased) = _List._pools_with_changed_devs(
+                devs().search(managed_objects)
+            )
+
             pools_with_props = [
-                MOPool(info) for objpath, info in pools().search(managed_objects)
+                (objpath, MOPool(info))
+                for objpath, info in pools().search(managed_objects)
             ]
 
             tables = [
@@ -898,9 +966,12 @@ class _List:
                     physical_size_triple(mopool),
                     properties_string(mopool),
                     self.uuid_formatter(mopool.Uuid()),
-                    _List.alert_string(mopool),
+                    _List.alert_string(
+                        _List.alert_codes(mopool)
+                        + _List._from_sets(pool_object_path, increased, decreased)
+                    ),
                 )
-                for mopool in pools_with_props
+                for (pool_object_path, mopool) in pools_with_props
             ]
 
             print_table(
@@ -917,15 +988,21 @@ class _List:
 
         else:
             this_uuid = pool_uuid.hex
-            mopool = MOPool(
-                next(
-                    pools(props={"Uuid": this_uuid})
-                    .require_unique_match(True)
-                    .search(managed_objects)
-                )[1]
+            (pool_object_path, mopool) = next(
+                pools(props={"Uuid": this_uuid})
+                .require_unique_match(True)
+                .search(managed_objects)
             )
 
-            self._print_detail_view(pool_uuid, mopool)
+            (increased, decreased) = _List._pools_with_changed_devs(
+                devs(props={"Pool": pool_object_path}).search(managed_objects)
+            )
+
+            device_change_codes = _List._from_sets(
+                pool_object_path, increased, decreased
+            )
+
+            self._print_detail_view(pool_uuid, MOPool(mopool), device_change_codes)
 
     def list_stopped_pools(self, *, pool_uuid=None):
         """

--- a/src/stratis_cli/_error_codes.py
+++ b/src/stratis_cli/_error_codes.py
@@ -120,12 +120,77 @@ class PoolAllocSpaceErrorCode(IntEnum):
         )
 
 
+class PoolDeviceSizeChangeCode(IntEnum):
+    """
+    Codes for identifying for a pool if a device that belongs to the pool has
+    been detected to have increased or reduced in size.
+    """
+
+    DEVICE_SIZE_INCREASED = 1
+    DEVICE_SIZE_DECREASED = 2
+
+    def __str__(self):
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED:
+            return f"IDS{str(self.value).zfill(3)}"
+
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED:
+            return f"WDS{str(self.value).zfill(3)}"
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    def explain(self):
+        """
+        Return an explanation of the return code.
+        """
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED:
+            return (
+                "At least one device belonging to this pool appears to have "
+                "increased in size."
+            )
+
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED:
+            return (
+                "At least one device belonging to this pool appears to have "
+                "decreased in size."
+            )
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    def summarize(self):
+        """
+        Return a short summary of the return code.
+        """
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED:
+            return "A device in this pool has increased in size."
+
+        if self is PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED:
+            return "A device in this pool has decreased in size."
+
+        assert False, "impossible error code reached"  # pragma: no cover
+
+    @staticmethod
+    def from_str(code_str):
+        """
+        Discover the code, if any, from the code string.
+
+        :returns: the code if it finds a match, otherwise None
+        :rtype: PoolAllocSpaceErrorCode or NoneType
+        """
+        return next(
+            (code for code in PoolDeviceSizeChangeCode if code_str == str(code)), None
+        )
+
+
 class PoolErrorCode:
     """
     Summary class for all pool error codes.
     """
 
-    CLASSES = [PoolMaintenanceErrorCode, PoolAllocSpaceErrorCode]
+    CLASSES = [
+        PoolMaintenanceErrorCode,
+        PoolAllocSpaceErrorCode,
+        PoolDeviceSizeChangeCode,
+    ]
 
     @staticmethod
     def codes():

--- a/src/stratis_cli/_parser/_pool.py
+++ b/src/stratis_cli/_parser/_pool.py
@@ -284,6 +284,36 @@ POOL_SUBCMDS = [
         ),
     ),
     (
+        "extend-data",
+        dict(
+            help=(
+                "Extend the pool's data capacity with additional storage "
+                "space offered by its component data devices through, e.g., "
+                "expansion of a component RAID device."
+            ),
+            args=[
+                ("pool_name", dict(action="store", help="Pool name")),
+                (
+                    "--device-uuid",
+                    dict(
+                        action="extend",
+                        dest="device_uuid",
+                        nargs="*",
+                        type=UUID,
+                        default=[],
+                        help=(
+                            "UUID of device to use; may be specified multiple "
+                            "times. If no devices are specified then all "
+                            "devices belonging to the pool that appear to have "
+                            "increased in size will be used."
+                        ),
+                    ),
+                ),
+            ],
+            func=PoolActions.extend_data,
+        ),
+    ),
+    (
         "bind",
         dict(
             help="Bind the given pool with an additional encryption facility",

--- a/tests/whitebox/_misc.py
+++ b/tests/whitebox/_misc.py
@@ -301,6 +301,23 @@ def get_pool(proxy, pool_name):
     )
 
 
+def get_pool_blockdevs(proxy, pool_name):
+    """
+    Get a generator of blockdevs for a given pool.
+    """
+    pool_object_path, _ = get_pool(proxy, pool_name)
+
+    # pylint: disable=import-outside-toplevel
+    # isort: LOCAL
+    from stratis_cli._actions._data import MODev, ObjectManager, devs
+
+    managed_objects = ObjectManager.Methods.GetManagedObjects(proxy, {})
+    return (
+        (op, MODev(info))
+        for (op, info) in devs(props={"Pool": pool_object_path}).search(managed_objects)
+    )
+
+
 def stop_pool(pool_name):
     """
     Stop a pool and return the UUID of the pool.

--- a/tests/whitebox/integration/pool/test_extend.py
+++ b/tests/whitebox/integration/pool/test_extend.py
@@ -1,0 +1,78 @@
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test 'extend-data'.
+"""
+
+# isort: STDLIB
+from uuid import UUID, uuid4
+
+# isort: LOCAL
+from stratis_cli import StratisCliErrorCodes
+from stratis_cli._actions._connection import get_object
+from stratis_cli._actions._constants import TOP_OBJECT
+from stratis_cli._errors import (
+    StratisCliPartialChangeError,
+    StratisCliResourceNotFoundError,
+)
+
+from .._misc import (
+    RUNNER,
+    TEST_RUNNER,
+    SimTestCase,
+    device_name_list,
+    get_pool_blockdevs,
+)
+
+_ERROR = StratisCliErrorCodes.ERROR
+_DEVICE_STRATEGY = device_name_list(1, 1)
+
+
+class ExtendDataTestCase(SimTestCase):
+    """
+    Test 'extend-data' on a sim pool.
+    """
+
+    _MENU = ["--propagate", "pool", "extend-data"]
+    _POOLNAME = "poolname"
+
+    def setUp(self):
+        super().setUp()
+        command_line = ["pool", "create", self._POOLNAME] + _DEVICE_STRATEGY()
+        RUNNER(command_line)
+
+    def test_bad_uuid(self):
+        """
+        Test trying to extend a device specifying a non-existent device UUID.
+        """
+        command_line = self._MENU + [self._POOLNAME, f"--device-uuid={str(uuid4())}"]
+        self.check_error(StratisCliResourceNotFoundError, command_line, _ERROR)
+
+    def test_no_uuid(self):
+        """
+        Test trying to extend a pool without specifying a UUID.
+        """
+        command_line = self._MENU + [self._POOLNAME]
+        TEST_RUNNER(command_line)
+
+    def test_good_uuid(self):
+        """
+        Test trying to extend a device specifying an existing device UUID.
+        """
+        _, props = next(get_pool_blockdevs(get_object(TOP_OBJECT), self._POOLNAME))
+        command_line = self._MENU + [
+            self._POOLNAME,
+            f"--device-uuid={str(UUID(props.Uuid()))}",
+        ]
+        self.check_error(StratisCliPartialChangeError, command_line, _ERROR)

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -203,6 +203,14 @@ class TestBadlyFormattedUuid(RunTestCase):
         for prefix in [[], ["--propagate"]]:
             self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
+    def test_bad_uuid_blockdev_2(self):
+        """
+        Test badly formed UUID for blockdev on extend-data.
+        """
+        command_line = ["pool", "extend-data", "poolname", "--device-uuid=not"]
+        for prefix in [[], ["--propagate"]]:
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
+
 
 class ParserSimTestCase(SimTestCase):
     """

--- a/tests/whitebox/unittest/test_error_fmt.py
+++ b/tests/whitebox/unittest/test_error_fmt.py
@@ -19,6 +19,7 @@ Test error type string formatting.
 import unittest
 
 # isort: LOCAL
+from stratis_cli._error_codes import PoolDeviceSizeChangeCode
 from stratis_cli._errors import (
     StratisCliGenerationError,
     StratisCliIncoherenceError,
@@ -69,3 +70,26 @@ class ErrorFmtTestCase(unittest.TestCase):
                 "action", "unique resource", "something failed"
             )
         )
+
+
+class SummarizeTestCase(unittest.TestCase):
+    """
+    Test summarize() function.
+    """
+
+    def _summarize_test(self, summary_value):
+        """
+        Check that the summary value is a str and is non-empty.
+
+        :param summary_value: the result of calling summary()
+        """
+        self.assertIsInstance(summary_value, str)
+        self.assertNotEqual(summary_value, "")
+
+    def test_pool_device_size_change_code(self):
+        """
+        Verify valid strings returned from summary() method.
+        """
+
+        self._summarize_test(PoolDeviceSizeChangeCode.DEVICE_SIZE_INCREASED.summarize())
+        self._summarize_test(PoolDeviceSizeChangeCode.DEVICE_SIZE_DECREASED.summarize())


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/50

Implements a new command: ```stratis pool extend-data``` and extends the output of ```blockdev list``` and ```pool list```. ```blockdev list``` shows the new size of the pool if different from the current in use-size. ```pool list``` displays an Alert on the pool, if different.

Supercedes #901