### PR TITLE
Update lowest supported Rust to 1.69.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: cargo
-          toolchain: 1.66.1  # LOWEST SUPPORTED RUST TOOLCHAIN
+          toolchain: 1.69.0  # LOWEST SUPPORTED RUST TOOLCHAIN
       - name: Check out stratisd
         run: git clone https://github.com/stratis-storage/stratisd.git
       - name: Build stratisd


### PR DESCRIPTION
Related: stratis-storage/project#622