### PR TITLE
Implement Clevis-related parser errors as parser errors

### DIFF
--- a/src/stratis_cli/_actions/_utils.py
+++ b/src/stratis_cli/_actions/_utils.py
@@ -21,10 +21,6 @@ import json
 from uuid import UUID
 
 from .._constants import PoolIdType
-from .._errors import (
-    StratisCliMissingClevisTangURLError,
-    StratisCliMissingClevisThumbprintError,
-)
 from .._stratisd_constants import (
     CLEVIS_KEY_TANG_TRUST_URL,
     CLEVIS_KEY_THP,
@@ -64,11 +60,9 @@ class ClevisInfo:
         clevis_info = None
         if namespace.clevis is not None:
             if namespace.clevis in ("nbde", "tang"):
-                if namespace.tang_url is None:
-                    raise StratisCliMissingClevisTangURLError()
+                assert namespace.tang_url is not None
 
-                if not namespace.trust_url and namespace.thumbprint is None:
-                    raise StratisCliMissingClevisThumbprintError()
+                assert namespace.trust_url or namespace.thumbprint is not None
 
                 clevis_config = {CLEVIS_KEY_URL: namespace.tang_url}
                 if namespace.trust_url:

--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -38,7 +38,6 @@ from ._errors import (
     StratisCliActionError,
     StratisCliEngineError,
     StratisCliIncoherenceError,
-    StratisCliParserError,
     StratisCliStratisdVersionError,
     StratisCliSynthUeventError,
     StratisCliUnknownInterfaceError,
@@ -198,9 +197,6 @@ def _interpret_errors_1(
             f"requested. It returned the following information via "
             f"the D-Bus: {error}."
         )
-
-    if isinstance(error, StratisCliParserError):
-        return f"You entered an invalid command: {error}"
 
     if isinstance(error, StratisCliUserError):
         return f"It appears that you issued an unintended command: {error}"

--- a/src/stratis_cli/_errors.py
+++ b/src/stratis_cli/_errors.py
@@ -229,39 +229,6 @@ class StratisCliNameConflictError(StratisCliUserError):
         return f"A {self.object_type} named {self.name} already exists"
 
 
-class StratisCliParserError(StratisCliRuntimeError):
-    """
-    Raised when user has passed arguments that the parser should reject
-    but can not due to its configuration limitations.
-    """
-
-
-class StratisCliMissingClevisTangURLError(StratisCliParserError):
-    """
-    Raised during pool creation if --clevis=[tang|nbde] specified but no
-    URL supplied.
-    """
-
-    def __str__(self):
-        return (
-            "Specified binding with Clevis Tang server, but URL was not "
-            "specified. Use --tang-url option to specify tang URL."
-        )
-
-
-class StratisCliMissingClevisThumbprintError(StratisCliParserError):
-    """
-    Raised during pool creation if --clevis=[tang|nbde] specified but neither
-    a thumbprint nor instructions to trust the URL were supplied.
-    """
-
-    def __str__(self):
-        return (
-            "Specified binding with Clevis Tang server, but neither "
-            "--thumbprint nor --trust-url option was specified."
-        )
-
-
 class StratisCliIncoherenceError(StratisCliRuntimeError):
     """
     Raised if there was a disagreement about state between the CLI

--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -42,6 +42,16 @@ def print_help(parser):
     return lambda _: parser.error("missing sub-command")
 
 
+def _add_groups(parser, groups):
+    """
+    Make an argument group.
+    """
+    for name, group in groups:
+        new_group = parser.add_argument_group(name, group["description"])
+        _add_args(new_group, group.get("args", []))
+        _add_mut_ex_args(new_group, group.get("mut_ex_args", []))
+
+
 def _add_args(parser, args):
     """
     Call subcommand.add_argument() based on args list.
@@ -83,6 +93,7 @@ def add_subcommand(subparser, cmd):
         for subcmd in subcmds:
             add_subcommand(subparsers, subcmd)
 
+    _add_groups(parser, info.get("groups", []))
     _add_args(parser, info.get("args", []))
     _add_mut_ex_args(parser, info.get("mut_ex_args", []))
 

--- a/src/stratis_cli/_parser/_pool.py
+++ b/src/stratis_cli/_parser/_pool.py
@@ -45,6 +45,69 @@ POOL_SUBCMDS = [
         "create",
         {
             "help": "Create a pool",
+            "groups": [
+                (
+                    "clevis",
+                    {
+                        "description": "Arguments controlling creation with Clevis encryption",
+                        "args": [
+                            (
+                                "--clevis",
+                                {
+                                    "default": None,
+                                    "type": str,
+                                    "help": ("Specification for binding with Clevis."),
+                                    "dest": "clevis",
+                                    "choices": ["nbde", "tang", "tpm2"],
+                                },
+                            ),
+                            (
+                                "--tang-url",
+                                {
+                                    "default": None,
+                                    "type": str,
+                                    "help": (
+                                        "URL of Clevis tang server (ignored if "
+                                        "--clevis=[tang|nbde] not set)"
+                                    ),
+                                    "dest": "tang_url",
+                                },
+                            ),
+                        ],
+                        "mut_ex_args": [
+                            (
+                                False,
+                                [
+                                    (
+                                        "--trust-url",
+                                        {
+                                            "action": "store_true",
+                                            "help": (
+                                                "Omit verification of tang server "
+                                                "credentials (ignored if "
+                                                "--clevis=[tang|nbde] not set)"
+                                            ),
+                                            "dest": "trust_url",
+                                        },
+                                    ),
+                                    (
+                                        "--thumbprint",
+                                        {
+                                            "action": "store",
+                                            "help": (
+                                                "Thumbprint of tang server at specified "
+                                                "URL (ignored if --clevis=[tang|nbde] not "
+                                                "set)"
+                                            ),
+                                            "dest": "thumbprint",
+                                        },
+                                    ),
+                                ],
+                            )
+                        ],
+                    },
+                )
+            ],
             "args": [
                 ("pool_name", {"action": "store", "help": "Name of new pool"}),
                 (
@@ -64,28 +127,6 @@ POOL_SUBCMDS = [
                     },
                 ),
                 (
-                    "--clevis",
-                    {
-                        "default": None,
-                        "type": str,
-                        "help": ("Specification for binding with Clevis."),
-                        "dest": "clevis",
-                        "choices": ["nbde", "tang", "tpm2"],
-                    },
-                ),
-                (
-                    "--tang-url",
-                    {
-                        "default": None,
-                        "type": str,
-                        "help": (
-                            "URL of Clevis tang server (ignored if "
-                            "--clevis=[tang|nbde] not set)"
-                        ),
-                        "dest": "tang_url",
-                    },
-                ),
-                (
                     "--no-overprovision",
                     {
                         "action": "store_true",
@@ -97,37 +138,6 @@ POOL_SUBCMDS = [
                         "dest": "no_overprovision",
                     },
                 ),
-            ],
-            "mut_ex_args": [
-                (
-                    False,
-                    [
-                        (
-                            "--trust-url",
-                            {
-                                "action": "store_true",
-                                "help": (
-                                    "Omit verification of tang server "
-                                    "credentials (ignored if "
-                                    "--clevis=[tang|nbde] not set)"
-                                ),
-                                "dest": "trust_url",
-                            },
-                        ),
-                        (
-                            "--thumbprint",
-                            {
-                                "action": "store",
-                                "help": (
-                                    "Thumbprint of tang server at specified "
-                                    "URL (ignored if --clevis=[tang|nbde] not "
-                                    "set)"
-                                ),
-                                "dest": "thumbprint",
-                            },
-                        ),
-                    ],
-                )
             ],
             "func": PoolActions.create_pool,
         },

--- a/tests/whitebox/integration/test_parser.py
+++ b/tests/whitebox/integration/test_parser.py
@@ -17,10 +17,6 @@ Test command-line argument parsing.
 
 # isort: LOCAL
 from stratis_cli import StratisCliErrorCodes
-from stratis_cli._errors import (
-    StratisCliMissingClevisTangURLError,
-    StratisCliMissingClevisThumbprintError,
-)
 
 from ._misc import RUNNER, RunTestCase, SimTestCase
 
@@ -68,24 +64,6 @@ class ParserTestCase(RunTestCase):
         for prefix in [[], ["--propagate"]]:
             self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
-    def test_create_with_clevis_1(self):
-        """
-        Test parsing when creating a pool w/ clevis tang, a URL, but both
-        thumbprint and --trust-url set.
-        """
-        command_line = [
-            "pool",
-            "create",
-            "--clevis=tang",
-            "--tang-url=url",
-            "--thumbprint=jkj",
-            "--trust-url",
-            "pn",
-            "/dev/n",
-        ]
-        for prefix in [[], ["--propagate"]]:
-            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
-
     def test_negative_filesystem_limit(self):
         """
         Verify that a negative integer filesystem limit is rejected.
@@ -115,6 +93,55 @@ class ParserTestCase(RunTestCase):
         Verify parser error on bogus pool code.
         """
         command_line = ["pool", "explain", "bogus"]
+        for prefix in [[], ["--propagate"]]:
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
+
+    def test_create_with_clevis_1(self):
+        """
+        Test parsing when creating a pool w/ clevis tang but no URL.
+        """
+        command_line = [
+            "--propagate",
+            "pool",
+            "create",
+            "--clevis=tang",
+            "pn",
+            "/dev/n",
+        ]
+        for prefix in [[], ["--propagate"]]:
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
+
+    def test_create_with_clevis_2(self):
+        """
+        Test parsing when creating a pool w/ clevis tang, a URL, but no
+        thumbprint or trust-url.
+        """
+        command_line = [
+            "pool",
+            "create",
+            "--clevis=tang",
+            "--tang-url=url",
+            "pn",
+            "/dev/n",
+        ]
+        for prefix in [[], ["--propagate"]]:
+            self.check_system_exit(prefix + command_line, _PARSE_ERROR)
+
+    def test_create_with_clevis_3(self):
+        """
+        Test parsing when creating a pool w/ clevis tang, a URL, but both
+        thumbprint and --trust-url set.
+        """
+        command_line = [
+            "pool",
+            "create",
+            "--clevis=tang",
+            "--tang-url=url",
+            "--thumbprint=jkj",
+            "--trust-url",
+            "pn",
+            "/dev/n",
+        ]
         for prefix in [[], ["--propagate"]]:
             self.check_system_exit(prefix + command_line, _PARSE_ERROR)
 
@@ -250,33 +277,3 @@ class ParserSimTestCase(SimTestCase):
         for subcommand in [["pool"], ["filesystem"], ["blockdev"]]:
             for prefix in [[], ["--propagate"]]:
                 self.assertEqual(RUNNER(prefix + subcommand), 0)
-
-    def test_create_with_clevis_1(self):
-        """
-        Test parsing when creating a pool w/ clevis tang but no URL.
-        """
-        command_line = [
-            "--propagate",
-            "pool",
-            "create",
-            "--clevis=tang",
-            "pn",
-            "/dev/n",
-        ]
-        self.check_error(StratisCliMissingClevisTangURLError, command_line, 1)
-
-    def test_create_with_clevis_2(self):
-        """
-        Test parsing when creating a pool w/ clevis tang, a URL, but no
-        thumbprint or trust-url.
-        """
-        command_line = [
-            "--propagate",
-            "pool",
-            "create",
-            "--clevis=tang",
-            "--tang-url=url",
-            "pn",
-            "/dev/n",
-        ]
-        self.check_error(StratisCliMissingClevisThumbprintError, command_line, 1)


### PR DESCRIPTION
Closes #1037

* Groups clevis-related options in the subcommand so they are grouped in the help text
* Some clevis-related options are conditionally dependent, i.e., they must be specified if the ```--clevis``` option is "tang" or "nbde", but otherwise not. Check if they are missing at parse time rather than at execution time so that, if they are missing, the error is understood to be a parse error (exit code 2).