### PR TITLE
Omit duplicate trees in the help text

### DIFF
--- a/src/stratis_cli/_parser/_parser.py
+++ b/src/stratis_cli/_parser/_parser.py
@@ -54,7 +54,9 @@ def gen_subparsers(parser, command_line):
         )
     ):
         for name, subparser in sorted(action.choices.items(), key=lambda x: x[0]):
-            yield from gen_subparsers(subparser, command_line + [name])
+            # if name is an alias then in it is not the name used in prog
+            if name == subparser.prog.split(" ")[-1]:
+                yield from gen_subparsers(subparser, command_line + [name])
 
 
 class PrintHelpAction(argparse.Action):


### PR DESCRIPTION
Related https://github.com/stratis-storage/stratis-cli/pull/1186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CLI subcommand parsing to avoid incorrectly traversing alias entries. This prevents misbehavior when using aliased subcommands, improving command discovery and stability.

* **Refactor**
  * Adjusted internal traversal logic to only recurse into canonical subcommands, reducing unnecessary processing while preserving existing behavior.

* **Chores**
  * No changes to public interfaces; behavior remains consistent for existing commands and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->