### PR TITLE
Organize Makefile coverage targets for greater convenience in GitHub Workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,10 +234,19 @@ jobs:
       - name: Workaround for D-Bus inotify
         run: cp stratisd.conf /usr/share/dbus-1/system.d
         working-directory: stratisd
-      - name: Run test
+      - name: Run tests
         run: >
           STRATISD=/usr/libexec/stratisd
           STRATIS_STRICT_POOL_FEATURES=1
           PYTHONPATH=./src
-          make -f Makefile coverage-no-html
+          make -f Makefile coverage
+        working-directory: stratis-cli
+      - name: Run tests without strict pool features enabled
+        run: >
+          STRATISD=/usr/libexec/stratisd
+          PYTHONPATH=./src
+          make -f Makefile coverage
+        working-directory: stratis-cli
+      - name: Run coverage report
+        run: make -f Makefile coverage-report
         working-directory: stratis-cli

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -78,6 +78,14 @@ jobs:
           PYTHONPATH=./src
           make -f Makefile all-tests
         working-directory: stratis-cli
+      - name: Run tests without strict pool features enabled
+        run: >
+          MONKEYTYPE=1
+          RUST_LOG=stratisd=debug
+          STRATISD=/usr/libexec/stratisd
+          PYTHONPATH=./src
+          make -f Makefile all-tests
+        working-directory: stratis-cli
       - name: Apply annotations
         run: PYTHONPATH=./src make apply
         working-directory: stratis-cli

--- a/Makefile
+++ b/Makefile
@@ -98,15 +98,19 @@ dbus-tests:
 unit-tests:
 	${PYTHON} -m unittest discover ${UNITTEST_OPTS} --start-directory ./tests/whitebox/unit
 
-.PHONY: coverage-no-html
-coverage-no-html:
-	python3 -m coverage --version
-	python3 -m coverage run --timid --branch -m unittest discover --quiet --top-level-directory ./tests/whitebox --start-directory ./tests/whitebox/integration >& /dev/null
-	python3 -m coverage run --timid --branch -a -m unittest discover --quiet --start-directory ./tests/whitebox/unit
+.PHONY: coverage
+coverage:
+	python3 -m coverage run -p --timid --branch -m unittest discover --quiet --top-level-directory ./tests/whitebox --start-directory ./tests/whitebox/integration >& /dev/null
+	python3 -m coverage run -p --timid --branch -m unittest discover --quiet --start-directory ./tests/whitebox/unit
+
+.PHONY: coverage-report
+coverage-report:
+	python3 -m coverage combine
 	python3 -m coverage report -m --fail-under=100 --show-missing --include="./src/*"
 
-.PHONY: coverage
-coverage: coverage-no-html
+.PHONY: coverage-html
+coverage-html:
+	python3 -m coverage combine
 	python3 -m coverage html --include="./src/*"
 
 .PHONY: all-tests

--- a/src/stratis_cli/_actions/_utils.py
+++ b/src/stratis_cli/_actions/_utils.py
@@ -131,9 +131,9 @@ class PoolFeature(Enum):
 
     @classmethod
     def _missing_(cls, value):
-        if _STRICT_POOL_FEATURES:  # pragma: no cover
+        if _STRICT_POOL_FEATURES:
             return None
-        return PoolFeature.UNRECOGNIZED  # pragma: no cover
+        return PoolFeature.UNRECOGNIZED
 
 
 class StoppedPool:  # pylint: disable=too-few-public-methods

--- a/tests/whitebox/unit/test_constants.py
+++ b/tests/whitebox/unit/test_constants.py
@@ -84,3 +84,28 @@ class PoolFeatureTestCase(unittest.TestCase):
             else:
                 self.assertEqual(str(feature), feature.value)
                 self.assertEqual(PoolFeature(feature.value), feature)
+
+    def test_many_types_missing(self):
+        """
+        Test the _missing_ method by passing many types of argument. This is
+        mostly to help monkeytype realize that the type of _missing_'s
+        value parameter is not just str.
+        """
+        if bool(int(os.environ.get("STRATIS_STRICT_POOL_FEATURES", 0))):
+
+            def test_func(val):
+                self.assertIsNone(
+                    PoolFeature._missing_(val)  # pylint: disable=protected-access
+                )
+
+        else:
+
+            def test_func(val):
+                self.assertEqual(
+                    PoolFeature._missing_(val),  # pylint: disable=protected-access
+                    PoolFeature.UNRECOGNIZED,
+                )
+
+        for val in [1, 0.347, ["a"], {"b": 32}, lambda x: 32]:
+            with self.subTest(val=val):
+                test_func(val)


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - CI workflows updated: test step renamed, added runs for both strict and non‑strict pool-feature modes, and a coverage-report step to aggregate results.
- Build
  - Coverage targets consolidated: new combined coverage, coverage-report (enforces threshold), and HTML output; legacy coverage-no-html target removed.
- Tests
  - Added unit test validating pool-feature handling across multiple input types under strict and non‑strict modes.
- Style
  - Removed test-coverage pragma annotations with no runtime impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->