### PR TITLE
Ignore pyright reportMissingImport error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 include = ["src", "tests", "bin"]
+reportMissingImports = false  # bug apparently introduced in pyright 1.1.405


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python type-checking configuration to suppress noisy missing-import warnings from a known tooling issue, reducing false positives in local development and CI logs.
  * Improves signal-to-noise in code reviews and build output.
  * No changes to runtime behavior, features, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->