### PR TITLE
Add return type to get_errors method

### DIFF
--- a/src/stratis_cli/_error_reporting.py
+++ b/src/stratis_cli/_error_reporting.py
@@ -17,6 +17,7 @@ Facilities for managing and reporting errors.
 # isort: STDLIB
 import os
 import sys
+from collections.abc import Iterator
 
 # isort: THIRDPARTY
 import dbus
@@ -79,7 +80,7 @@ def _interface_name_to_common_name(interface_name):
     raise StratisCliUnknownInterfaceError(interface_name)  # pragma: no cover
 
 
-def get_errors(exc: BaseException):
+def get_errors(exc: BaseException) -> Iterator[BaseException]:
     """
     Generates a sequence of exceptions starting with exc and following the chain
     of causes.


### PR DESCRIPTION
Related #1207 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added explicit return type annotations to an internal error-iteration utility to improve type safety and clarity.
  * No changes to runtime behavior or error-handling semantics; user workflows remain unaffected.
  * Enhances maintainability and developer tooling (type checking, IDE insights) for future development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->