### PR TITLE
pyright: Turn off reportMissingImports only in tests directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.pyright]
 include = ["src", "tests", "bin"]
 pythonVersion = "3.12"
-reportMissingImports = false  # bug apparently introduced in pyright 1.1.405
+executionEnvironments = [
+  # bug apparently introduced in pyright 1.1.405
+  { root  = "tests", reportMissingImports = "none" }
+]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted static analysis configuration so missing-import suppression applies only within the test environment, improving type-check accuracy in other areas.
* **Tests**
  * Tightened type-checking behavior for tests to surface import issues during development.

No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->