### PR TITLE
Revert "Use Fedora specfile for Packit builds"

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,7 +10,7 @@ downstream_package_name: stratis-cli
 actions:
   post-upstream-clone:
     - "git clone https://github.com/stratis-storage/ci --depth=1 ../distro"
-    - "bash -c '(cd ../distro; wget https://src.fedoraproject.org/rpms/stratis-cli/raw/rawhide/f/stratis-cli.spec)'"
+    - "mv ../distro/mockbuild_test/stratis-cli.spec ../distro/stratis-cli.spec"
   create-archive:
     - "sh -c 'python3 ../distro/release_management/create_artifacts.py ../distro/ --pre-release --specfile-path=../distro/stratis-cli.spec stratis-cli'"
   fix-spec-file:
@@ -19,11 +19,9 @@ actions:
     - "python3 setup.py --version"
 
 srpm_build_deps:
-  - git
   - python3-pip
+  - git
   - python3-semantic_version
-  - wget2
-  - wget2-wget
 
 jobs:
   - job: copr_build


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined packaging workflow by using a prebuilt spec file instead of downloading it.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->